### PR TITLE
add jupyter-ai (Claude + OpenCode) and jupyter-geoagent to CPU image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -9,6 +9,9 @@ RUN bash /tmp/install-kubectl-tools.sh && rm /tmp/install-kubectl-tools.sh
 COPY install-claude.sh /tmp/install-claude.sh
 RUN bash /tmp/install-claude.sh && rm /tmp/install-claude.sh
 
+COPY install-jupyter-ai.sh /tmp/install-jupyter-ai.sh
+RUN bash /tmp/install-jupyter-ai.sh && rm /tmp/install-jupyter-ai.sh
+
 USER ${NB_USER}
 
 RUN install2.r rsvg nimble jqr av

--- a/images/install-jupyter-ai.sh
+++ b/images/install-jupyter-ai.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Node.js + npm are needed for @zed-industries/claude-agent-acp, the ACP
+# bridge that jupyter-ai spawns when the user @mentions @Claude in the
+# chat panel. OpenCode ships its own standalone binary, already installed
+# to /usr/local/bin/opencode by the base image.
+apt-get update
+apt-get install -y --no-install-recommends nodejs npm
+rm -rf /var/lib/apt/lists/*
+
+# Claude ACP bridge — installs a `claude-agent-acp` binary onto PATH.
+npm install -g @zed-industries/claude-agent-acp
+npm cache clean --force
+
+# jupyter-ai v3 pulls in jupyter-ai-acp-client, jupyter-ai-chat-commands,
+# and jupyter-ai-persona-manager, which register the Claude / OpenCode /
+# Goose personas automatically. jupyter-geoagent (this lab) registers
+# the GeoAgent Map launcher tile plus `geoagent:*` JupyterLab commands
+# so the LLM personas can drive the map directly from chat.
+/opt/venv/bin/pip install --no-cache-dir \
+  "jupyter-ai>=3,<4" \
+  "jupyter-geoagent @ git+https://github.com/boettiger-lab/jupyter-geoagent.git@main"


### PR DESCRIPTION
## Summary

Adds LLM-powered in-JupyterLab map exploration to the CPU image by installing jupyter-ai v3 (with the ACP-based Claude and OpenCode personas) and the jupyter-geoagent lab extension.

- New \`install-jupyter-ai.sh\`:
  - apt: \`nodejs\`, \`npm\` — needed for the Claude ACP bridge
  - npm: \`@zed-industries/claude-agent-acp\` — spawned when the user @mentions @Claude
  - pip: \`jupyter-ai>=3,<4\` + \`jupyter-geoagent\` (from git main)
- \`opencode\` was already on PATH in the Rocker base image; jupyter-ai picks it up for the @OpenCode persona without extra work.
- Dockerfile gets one extra COPY/RUN pair following the existing \`install-claude.sh\` convention.

## Verified against a local build

\`\`\`
$ docker run --rm <image> bash -lc 'which claude-agent-acp opencode node ...'
/usr/local/bin/claude-agent-acp
/usr/local/bin/opencode
/usr/bin/node
...
\`\`\`

Lab extensions enabled: \`@boettiger-lab/jupyter-geoagent\`, \`@jupyter-ai/acp-client\`, \`@jupyter-ai/chat-commands\`, \`@jupyter-ai/persona-manager\`, \`@jupyter-ai/router\`, \`jupyterlab-commands-toolkit\`. Server extensions validated.

## Test plan

- [ ] Launch the CPU image in JupyterHub
- [ ] Click **GeoAgent Map** in the launcher — map opens
- [ ] Open a jupyter-ai chat, @Claude and @OpenCode are selectable
- [ ] \`@Claude use list_all_commands with query="geoagent:"\` returns the map tools