### PR TITLE
fix(images): repair claude symlink + use Node 22 for ACP bridge

### DIFF
--- a/images/install-claude.sh
+++ b/images/install-claude.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install Claude Code CLI — installer hardcodes $HOME/.local/bin, so move to /usr/local/bin
+# Install Claude Code CLI. The installer drops a versioned binary tree
+# under $HOME/.local/share/claude/versions/<ver>/ and a symlink at
+# $HOME/.local/bin/claude pointing to it. Moving just the symlink and
+# deleting the share dir leaves a dangling link, so move the whole tree
+# to /opt/claude and retarget the /usr/local/bin/claude symlink.
 curl -fsSL https://claude.ai/install.sh | bash && \
-  mv "${HOME}/.local/bin/claude" /usr/local/bin/claude && \
-  rm -rf "${HOME}/.local/share/claude" "${HOME}/.local/bin/claude"
+  CLAUDE_TARGET="$(readlink "${HOME}/.local/bin/claude")" && \
+  mv "${HOME}/.local/share/claude" /opt/claude && \
+  ln -sf "${CLAUDE_TARGET/${HOME}\/.local\/share\/claude/\/opt\/claude}" /usr/local/bin/claude && \
+  rm -rf "${HOME}/.local"
 
 # claude VSCode extension is available on Open VSX as Anthropic.claude-code
 # Must run as NB_USER: code-server 4.x does not support --allow-root

--- a/images/install-jupyter-ai.sh
+++ b/images/install-jupyter-ai.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Node.js + npm are needed for @zed-industries/claude-agent-acp, the ACP
-# bridge that jupyter-ai spawns when the user @mentions @Claude in the
-# chat panel. OpenCode ships its own standalone binary, already installed
+# Node.js (with bundled npm) is needed for @zed-industries/claude-agent-acp,
+# the ACP bridge that jupyter-ai spawns when the user @mentions @Claude in
+# the chat panel. OpenCode ships its own standalone binary, already installed
 # to /usr/local/bin/opencode by the base image.
-apt-get update
-apt-get install -y --no-install-recommends nodejs npm
+#
+# Ubuntu 24.04's apt ships Node 18, but the ACP bridge uses ESM import
+# attributes (`with { type: "json" }`) which require Node >= 20, so pull
+# Node 22 LTS from NodeSource instead.
+curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+apt-get install -y --no-install-recommends nodejs
 rm -rf /var/lib/apt/lists/*
 
 # Claude ACP bridge — installs a `claude-agent-acp` binary onto PATH.


### PR DESCRIPTION
## Summary

Two related fixes for the JupyterHub CPU image, surfaced while debugging the same problems in `boettiger-lab/jupyter-geoagent`:

- **`install-claude.sh`** — the Claude installer now drops a versioned binary tree at `$HOME/.local/share/claude/versions/<ver>/` and `$HOME/.local/bin/claude` is a symlink into it. The previous logic moved the *symlink* to `/usr/local/bin/claude` and then deleted the share dir, leaving a dangling link. Move the whole tree to `/opt/claude` and retarget the symlink.
- **`install-jupyter-ai.sh`** — Ubuntu 24.04's apt ships Node 18, but `@zed-industries/claude-agent-acp` uses ESM import attributes (`with { type: "json" }`) that require Node ≥ 20, so the bridge crashed at startup with `SyntaxError: Unexpected token 'with'`. Pull Node 22 LTS from NodeSource instead.

## How the bugs were missed

PR #11's smoke test only ran `which claude-agent-acp` — neither `claude --version` nor an actual ACP handshake, so both failures went undetected.

## Verified

Reproduced both failures and verified the fixes end-to-end against `ghcr.io/rocker-org/ml-spatial`:

```
$ claude --version
2.1.120 (Claude Code)
$ node --version
v22.22.2
$ npm --version
10.9.7
$ claude-agent-acp   # starts cleanly, no SyntaxError
```

## Test plan

- [ ] CI image build succeeds
- [ ] In a single-user pod: `claude --version` runs (no dangling symlink)
- [ ] In a single-user pod: `node --version` reports v22.x
- [ ] In a JupyterLab session: `@Claude` in jupyter-ai chat returns a real response (exercises the ACP bridge)