### PR TITLE
Fix flaky bridge labextension verification in image build

### DIFF
--- a/images/install-jupyter-ai.sh
+++ b/images/install-jupyter-ai.sh
@@ -41,8 +41,15 @@ JUPYTER_AI_ACP_BRIDGE_REF="f653dbef872e14a5ea9e8952461579f22126b164"
   "jupyter-ai-acp-bridge @ git+https://github.com/cboettig/jupyter-ai.git@${JUPYTER_AI_ACP_BRIDGE_REF}#subdirectory=jupyter-ai-acp-bridge" \
   "jupyter-geoagent @ git+https://github.com/boettiger-lab/jupyter-geoagent.git@main"
 
-# Fail the build loudly if the bridge labextension didn't compile/register,
+# Fail the build loudly if the bridge labextension didn't compile/ship,
 # rather than shipping an image where the toolbar silently never appears.
-/opt/venv/bin/jupyter labextension list 2>&1 | grep -q "@jupyter-ai/acp-bridge.*enabled.*OK" \
-  || { echo "ERROR: @jupyter-ai/acp-bridge labextension not enabled" >&2; \
-       /opt/venv/bin/jupyter labextension list; exit 1; }
+# Gate on the prebuilt federated-extension artifact on disk rather than
+# `jupyter labextension list`: the first post-install invocation of that
+# command races (it triggers extension discovery and reports the extension
+# as not-yet-enabled, self-healing on a second call), which gives false
+# negatives under the slower multi-arch CI build. The artifact's presence is
+# deterministic and is what actually makes the toolbar load at runtime.
+BRIDGE_LABEXT="/opt/venv/share/jupyter/labextensions/@jupyter-ai/acp-bridge"
+test -f "${BRIDGE_LABEXT}/package.json" \
+  || { echo "ERROR: @jupyter-ai/acp-bridge labextension artifact missing at ${BRIDGE_LABEXT}" >&2; \
+       ls -la "$(dirname "${BRIDGE_LABEXT}")" 2>&1 || true; exit 1; }


### PR DESCRIPTION
## Problem

The CPU image build (`k8s:latest`) was failing on the `@jupyter-ai/acp-bridge` verification step added in #15 — see [run 26929148623](https://github.com/boettiger-lab/k8s/actions/runs/26929148623).

The check grepped `jupyter labextension list` for `enabled OK`. But that command's **first** post-install invocation races: it triggers extension discovery and reports the bridge as not-yet-enabled, self-healing on a second call ~2s later. The failed build log shows exactly this — the check errored at `03:50:48`, and the debug dump 2s later at `03:50:51` showed `@jupyter-ai/acp-bridge v0.0.1 enabled OK`. Locally the first call happened to settle (so #15 passed local testing); under the slower multi-arch CI build it didn't.

**The bridge itself was installed correctly** — only the verification produced a false negative.

## Fix

Gate on the deterministic thing: the prebuilt federated-extension artifact on disk (`share/jupyter/labextensions/@jupyter-ai/acp-bridge/package.json`), which is what actually makes the toolbar load at runtime. No race, no build trigger.

## Verified

Local `docker build` passes; artifact confirmed present at `/opt/venv/share/jupyter/labextensions/@jupyter-ai/acp-bridge/package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)