### PR TITLE
Fix CPU image build path filter to match Dockerfile inputs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,7 +4,16 @@ on:
   schedule:
     - cron: '0 0 * * 0'
   push:
-    paths: ['images/Dockerfile',  'images/install.r', 'images/rl-env.yml', 'images/spatial-env.yml', 'images/jupyter-ai.yml']
+    # Trigger on the files the CPU Dockerfile actually consumes. The previous
+    # list referenced install.r / spatial-env.yml / jupyter-ai.yml (which don't
+    # exist) and omitted the install-*.sh scripts the Dockerfile COPYs and runs,
+    # so script edits silently never rebuilt the image — only the weekly
+    # schedule or a manual dispatch did.
+    paths:
+      - 'images/Dockerfile'
+      - 'images/install-kubectl-tools.sh'
+      - 'images/install-claude.sh'
+      - 'images/install-jupyter-ai.sh'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The CPU image workflow's `push:` trigger filtered on:

```
['images/Dockerfile', 'images/install.r', 'images/rl-env.yml', 'images/spatial-env.yml', 'images/jupyter-ai.yml']
```

Three of those files **don't exist** (`install.r`, `spatial-env.yml`, `jupyter-ai.yml`), and the list **omits the `install-*.sh` scripts** the CPU `Dockerfile` actually `COPY`s and runs. So edits to those scripts never triggered a rebuild — only the weekly `cron` or a manual dispatch did.

This is exactly what bit us with the `jupyter-ai-acp-bridge` work: merging the change to `install-jupyter-ai.sh` published nothing, and the image only updated after a manual `workflow_dispatch`.

## Fix

Filter on the files the CPU `Dockerfile` genuinely consumes:

```yaml
paths:
  - 'images/Dockerfile'
  - 'images/install-kubectl-tools.sh'
  - 'images/install-claude.sh'
  - 'images/install-jupyter-ai.sh'
```

(`rl-env.yml` is dropped — the CPU Dockerfile doesn't reference it. The GPU workflow keeps its own separate filter.)

YAML validated with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)