### PR TITLE
Replace jupyter-ai bridge with standalone jupyterlab-acp

### DIFF
--- a/images/install-jupyter-ai.sh
+++ b/images/install-jupyter-ai.sh
@@ -1,55 +1,49 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Node.js (with bundled npm) is needed for @zed-industries/claude-agent-acp,
-# the ACP bridge that jupyter-ai spawns when the user @mentions @Claude in
-# the chat panel. OpenCode ships its own standalone binary, already installed
-# to /usr/local/bin/opencode by the base image.
+# Node.js (with bundled npm) is needed for two things here: the
+# @zed-industries/claude-agent-acp binary (the Claude Code ACP agent that
+# jupyterlab-acp drives), and building jupyter-geoagent's JupyterLab extension
+# frontend from source via jlpm. OpenCode ships its own standalone binary,
+# already on PATH at /usr/local/bin/opencode in the base image.
 #
-# Ubuntu 24.04's apt ships Node 18, but the ACP bridge uses ESM import
+# Ubuntu 24.04's apt ships Node 18, but the ACP agent uses ESM import
 # attributes (`with { type: "json" }`) which require Node >= 20, so pull
 # Node 22 LTS from NodeSource instead.
 curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
 apt-get install -y --no-install-recommends nodejs
 rm -rf /var/lib/apt/lists/*
 
-# Claude ACP bridge — installs a `claude-agent-acp` binary onto PATH.
+# Claude ACP agent — installs a `claude-agent-acp` binary onto PATH.
 npm install -g @zed-industries/claude-agent-acp
 npm cache clean --force
 
-# jupyter-ai v3 pulls in jupyter-ai-acp-client, jupyter-ai-chat-commands,
-# and jupyter-ai-persona-manager, which register the Claude / OpenCode /
-# Goose personas automatically. jupyter-geoagent (this lab) registers
-# the GeoAgent Map launcher tile plus `geoagent:*` JupyterLab commands
-# so the LLM personas can drive the map directly from chat.
+# jupyterlab-acp (SchmidtDSE) provides Jupyter-native, per-chat access to
+# coding agents over the Agent Client Protocol — Claude Code, OpenCode, Goose,
+# Gemini, etc. It is standalone (no jupyter_ai_* dependency), keeps agent
+# selection separate from model choice, edits the open .ipynb directly, and
+# discovers agents from the shared ACP Agent Registry rather than a hard-coded
+# list. Shipped as a prebuilt wheel on PyPI, so it needs no Node build step.
+# https://schmidtdse.github.io/jupyterlab-acp/
 #
-# jupyter-ai-acp-bridge is our PoC fork that adds a Zed-style per-chat
-# harness toolbar (model picker, mode picker, config toggles, slash-command
-# autocomplete) to the new-chat dialog and supersedes the legacy `@Claude` /
-# `@OpenCode` personas. It depends on (but does not fork) the upstream
-# jupyter_ai_acp_client / persona_manager packages that jupyter-ai>=3 already
-# provides. Not on PyPI; installed from cboettig/jupyter-ai. The build hook
-# runs jlpm to bundle the JupyterLab extension, which is why Node must be
-# installed above this step.
-#
-# Pinned to a commit SHA rather than the acp-bridge-impl branch tip so the
-# weekly no-cache image rebuild is reproducible — bump this when the bridge
-# lands new work.
-JUPYTER_AI_ACP_BRIDGE_REF="f653dbef872e14a5ea9e8952461579f22126b164"
+# jupyter-geoagent (this lab) registers the GeoAgent Map launcher tile plus
+# `geoagent:*` JupyterLab commands so agents can drive the map from chat. It is
+# installed from git and builds its frontend via jlpm, which is why Node must
+# be installed above this step.
 /opt/venv/bin/pip install --no-cache-dir \
-  "jupyter-ai>=3,<4" \
-  "jupyter-ai-acp-bridge @ git+https://github.com/cboettig/jupyter-ai.git@${JUPYTER_AI_ACP_BRIDGE_REF}#subdirectory=jupyter-ai-acp-bridge" \
+  jupyterlab-acp \
   "jupyter-geoagent @ git+https://github.com/boettiger-lab/jupyter-geoagent.git@main"
 
-# Fail the build loudly if the bridge labextension didn't compile/ship,
-# rather than shipping an image where the toolbar silently never appears.
-# Gate on the prebuilt federated-extension artifact on disk rather than
-# `jupyter labextension list`: the first post-install invocation of that
-# command races (it triggers extension discovery and reports the extension
-# as not-yet-enabled, self-healing on a second call), which gives false
-# negatives under the slower multi-arch CI build. The artifact's presence is
-# deterministic and is what actually makes the toolbar load at runtime.
-BRIDGE_LABEXT="/opt/venv/share/jupyter/labextensions/@jupyter-ai/acp-bridge"
-test -f "${BRIDGE_LABEXT}/package.json" \
-  || { echo "ERROR: @jupyter-ai/acp-bridge labextension artifact missing at ${BRIDGE_LABEXT}" >&2; \
-       ls -la "$(dirname "${BRIDGE_LABEXT}")" 2>&1 || true; exit 1; }
+# Fail the build loudly if either prebuilt labextension didn't ship, rather
+# than shipping an image where the chat panel or map launcher silently never
+# appears. Gate on the federated-extension artifact on disk (deterministic)
+# rather than `jupyter labextension list`, whose first post-install invocation
+# races (it triggers extension discovery and can report an extension as
+# not-yet-enabled, self-healing on a second call) and gives false negatives
+# under the slower multi-arch CI build.
+LABEXT_DIR="/opt/venv/share/jupyter/labextensions"
+for ext in "jupyterlab-acp" "@geojupyter/jupyter-geoagent"; do
+  test -f "${LABEXT_DIR}/${ext}/package.json" \
+    || { echo "ERROR: ${ext} labextension artifact missing at ${LABEXT_DIR}/${ext}" >&2; \
+         ls -la "${LABEXT_DIR}" 2>&1 || true; exit 1; }
+done


### PR DESCRIPTION
## What

Switches the in-lab ACP coding-agent chat from the cboettig/jupyter-ai `acp-bridge-impl` fork (added in #15/#16) to **[SchmidtDSE/jupyterlab-acp](https://schmidtdse.github.io/jupyterlab-acp/)**, a standalone prebuilt JupyterLab extension.

## Why

`jupyterlab-acp` is self-contained — **no `jupyter_ai_*` dependency** — and provides the per-chat agent experience directly (agent selection separate from model choice, live `.ipynb` editing, dynamic agent discovery via the shared ACP registry). Since `jupyter-ai` (v3) was installed *only* to host the old bridge, and `jupyter-geoagent` doesn't depend on it, we drop `jupyter-ai` entirely.

## Changes

- **Add** `jupyterlab-acp` (PyPI, prebuilt wheel — no Node build step).
- **Drop** `jupyter-ai>=3` and the `jupyter-ai-acp-bridge` fork package.
- **Keep** Node 22 + `claude-agent-acp` (the ACP agent binary; Node also builds geoagent's frontend) and `jupyter-geoagent`.
- Artifact check now verifies **both** `jupyterlab-acp` and `@geojupyter/jupyter-geoagent` labextensions shipped.

## Verified locally

Build passes; `jupyterlab-acp-0.0.1` + `jupyter-geoagent-0.1.0` installed, both labextension artifacts present, `jupyter-ai` absent, `claude-agent-acp` on PATH. Dependency tree is much smaller (only `agent-client-protocol` added transitively).

> Note: the file is still named `install-jupyter-ai.sh` though it no longer installs jupyter-ai — left as-is to avoid churning the Dockerfile + workflow path filter; can rename in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)