### PR TITLE
ci: build arm64 on native runners instead of QEMU

### DIFF
--- a/.github/workflows/docker-gpu-image.yml
+++ b/.github/workflows/docker-gpu-image.yml
@@ -13,17 +13,33 @@ on:
       - 'images/install-claude.sh'
       - 'images/install-jupyter-ai.sh'
       - '.github/workflows/docker-gpu-image.yml'
+
+# Build each architecture on its own native runner (arm64 on ubuntu-24.04-arm,
+# no QEMU), push by digest, then assemble one multi-arch manifest. Native
+# per-arch builds are much faster than emulating arm64, and each runner only
+# materializes one arch filesystem -- halving the disk pressure that the large
+# no-cache CUDA+torch image puts on a stock ~14G runner.
+env:
+  IMAGE: ghcr.io/boettiger-lab/k8s-gpu
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    if: github.repository == 'boettiger-lab/k8s'
+    runs-on: ${{ matrix.runner }}
     permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm   # native arm64 runner, no QEMU
     steps:
-    # The no-cache multi-arch (amd64+arm64) CUDA+torch build materializes both
-    # arch filesystems at once and overruns the ~14G free on a stock runner.
-    # The old inline `rm` of android/dotnet/ghc wasn't enough once the image
-    # grew the claude + jupyter-sidekick assistant layers, so reclaim the big
-    # preinstalled toolchains (hostedtoolcache, .NET, GHC, Android, Swift, CodeQL)
-    # via the well-worn free-disk-space action — frees ~30G.
+      - name: Prepare platform name
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
       - name: cleanup disk space
         uses: jlumbroso/free-disk-space@main
         with:
@@ -31,25 +47,61 @@ jobs:
           large-packages: false
           docker-images: false
           swap-storage: false
-      - uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        if: github.repository == 'boettiger-lab/k8s'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-      - name: Build and push
-        if: github.repository == 'boettiger-lab/k8s'
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: images/
           file: images/Dockerfile.gpu
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform }}
           no-cache: true
-          tags: ghcr.io/boettiger-lab/k8s-gpu:latest
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: github.repository == 'boettiger-lab/k8s'
+    runs-on: ubuntu-latest
+    needs: build
+    permissions: write-all
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create -t "${IMAGE}:latest" \
+            $(printf "${IMAGE}@sha256:%s " *)
+      - name: Inspect
+        run: docker buildx imagetools inspect "${IMAGE}:latest"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,37 +15,89 @@ on:
       - 'images/install-claude.sh'
       - 'images/install-jupyter-ai.sh'
       - '.github/workflows/docker-image.yml'
+
+# Build each architecture on its own native runner (arm64 on ubuntu-24.04-arm,
+# no QEMU), push by digest, then assemble one multi-arch manifest. Native
+# per-arch builds are much faster than emulating arm64, and each runner only
+# materializes one arch filesystem.
+env:
+  IMAGE: ghcr.io/boettiger-lab/k8s
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    if: github.repository == 'boettiger-lab/k8s'
+    runs-on: ${{ matrix.runner }}
     permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm   # native arm64 runner, no QEMU
     steps:
-    # For biggish images, github actions runs out of disk space.
-    # So we cleanup some unwanted things in the disk image, and reclaim that space for our docker use
-    # https://github.com/actions/virtual-environments/issues/2606#issuecomment-772683150
-    # and https://github.com/easimon/maximize-build-space/blob/b4d02c14493a9653fe7af06cc89ca5298071c66e/action.yml#L104
-    # This gives us a total of about 52G of free space, which should be enough for now
+      - name: Prepare platform name
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
       - name: cleanup disk space
         run: |
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
           df -h
-      - uses: actions/checkout@v3
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        if: github.repository == 'boettiger-lab/k8s'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-      - name: Build and push
-        if: github.repository == 'boettiger-lab/k8s'
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: images/
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/boettiger-lab/k8s:latest
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: github.repository == 'boettiger-lab/k8s'
+    runs-on: ubuntu-latest
+    needs: build
+    permissions: write-all
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create -t "${IMAGE}:latest" \
+            $(printf "${IMAGE}@sha256:%s " *)
+      - name: Inspect
+        run: docker buildx imagetools inspect "${IMAGE}:latest"


### PR DESCRIPTION
## What

Both `docker-image.yml` (`k8s`) and `docker-gpu-image.yml` (`k8s-gpu`) built `linux/amd64,linux/arm64` in a **single** job under QEMU, so arm64 was slow-emulated and both arch filesystems shared one ~14G runner (GPU builds ~24m, disk-tight).

This splits each arch onto its **own native runner** — `linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm` (GitHub's hosted arm64 runners, free for public repos, GA since Jan 2025) — pushes **by digest**, then a merge job assembles the multi-arch `:latest` manifest. No QEMU; each runner holds only one arch.

## Why

Native arm64 is substantially faster than emulation, and the per-arch split removes the disk pressure that's been making these builds tight. arm64 stays a first-class target (the cluster includes arm64 nodes).

## Validate on first run
- [ ] `ubuntu-24.04-arm` runners pick up the arm64 job (free for this public repo).
- [ ] `imagetools create` produces a 2-arch manifest (`imagetools inspect` shows amd64 + arm64).
- [ ] GPU build fits disk per-arch (it keeps `no-cache: true` + the free-disk-space step).

Pairs with rocker-org/ml#46 (same native-runner split upstream).