### PR TITLE
chore: gitignore local-only ops/ maintenance journal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ id_ed25519_sk
 # Hugo local artifacts
 hugo_extended_*.tar.gz
 
+# Local-only ops/maintenance journal (drive serials, host topology, security posture)
+/ops/
+


### PR DESCRIPTION
Adds `/ops/` to .gitignore for local host-maintenance/health notes that contain sensitive operational detail (drive serials, node topology, security posture) and should stay local rather than reach this public remote. Only the .gitignore line is tracked; the `ops/` contents stay untracked/local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)