### PR TITLE
jupyterhub: add cirrus.carlboettiger.info short-URL redirect

### DIFF
--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -67,6 +67,17 @@ These scripts:
 2. Update Helm repositories.
 3. Deploy using the appropriate config files.
 
+### Short-URL Redirect (Cirrus)
+
+JupyterHub is served at `jupyterhub.cirrus.carlboettiger.info`. The short URL
+`cirrus.carlboettiger.info` permanently (301) redirects to it via a standalone
+Traefik ingress + middleware (not part of the Helm chart, so the OAuth callback
+URL stays unchanged). Apply it once after deploying:
+
+```bash
+kubectl apply -n jupyter -f cirrus-redirect.yaml
+```
+
 ## Configuration
 
 ### Secrets Management

--- a/jupyterhub/cirrus-redirect.yaml
+++ b/jupyterhub/cirrus-redirect.yaml
@@ -1,0 +1,54 @@
+# Short-URL redirect: cirrus.carlboettiger.info -> jupyterhub.cirrus.carlboettiger.info
+#
+# JupyterHub stays served at its established host (jupyterhub.cirrus.carlboettiger.info,
+# see public-config.yaml) so the GitHub OAuth callback URL is unchanged. This just adds a
+# convenience short URL that permanently redirects to it.
+#
+# NOTE: Assumes cert-manager and external-dns are set up (same as the other cirrus ingresses).
+# A TLS cert is still issued for cirrus.carlboettiger.info so the browser completes TLS
+# before receiving the 301 redirect.
+#
+# Deploy:  kubectl apply -n jupyter -f cirrus-redirect.yaml
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cirrus-shorturl-redirect
+  namespace: jupyter
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
+    # Apply the redirect middleware to this router (format: <namespace>-<name>@kubernetescrd)
+    traefik.ingress.kubernetes.io/router.middlewares: jupyter-cirrus-shorturl-redirect@kubernetescrd
+spec:
+  ingressClassName: traefik
+  rules:
+  - host: cirrus.carlboettiger.info
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        # Backend is never reached (the middleware redirects first), but an Ingress
+        # requires one. Point at the existing JupyterHub proxy service.
+        backend:
+          service:
+            name: proxy-public
+            port:
+              number: 80
+  tls:
+  - hosts:
+    - cirrus.carlboettiger.info
+    secretName: cirrus-shorturl-tls
+
+---
+# Traefik v3 middleware: permanent (301) redirect, preserving the request path.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: cirrus-shorturl-redirect
+  namespace: jupyter
+spec:
+  redirectRegex:
+    regex: ^https?://cirrus\.carlboettiger\.info/(.*)
+    replacement: https://jupyterhub.cirrus.carlboettiger.info/${1}
+    permanent: true


### PR DESCRIPTION
Adds `cirrus.carlboettiger.info` as a convenience short URL that permanently (301) redirects to the established JupyterHub host `jupyterhub.cirrus.carlboettiger.info`, preserving the request path.

## Why this shape
Deliberately **not** folded into the Helm chart (`public-config.yaml`): adding a second host there would either serve the hub on both names (no redirect) or force a change to the GitHub OAuth callback URL. Instead this is a standalone Traefik `Ingress` + `Middleware`, so the OAuth callback stays untouched. A TLS cert is still issued for the short host (DNS-01 via Cloudflare) so TLS completes before the browser receives the redirect.

## Verified live
- `https://cirrus.carlboettiger.info/` → `301` → `https://jupyterhub.cirrus.carlboettiger.info/`
- Path preserved: `/hub/login` → `/hub/login`
- Follow-through lands on the JupyterHub login page (`200`)
- Cert `cirrus-shorturl-tls` issued and `Ready`

Already applied to the cluster (`kubectl apply -n jupyter -f jupyterhub/cirrus-redirect.yaml`); this PR is the record.
