### PR TITLE
armada: raise redis/postgres memory limits to stop OOM crashloop

### DIFF
--- a/armada/postgres-values.yaml
+++ b/armada/postgres-values.yaml
@@ -11,3 +11,11 @@ primary:
   persistence:
     storageClass: local-path
     size: 10Gi
+  # Default bitnami "nano" preset (192Mi limit) OOM-killed postgres (16 restarts).
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 2Gi

--- a/armada/redis-values.yaml
+++ b/armada/redis-values.yaml
@@ -7,3 +7,12 @@ master:
   persistence:
     storageClass: local-path
     size: 5Gi
+  # Default bitnami "nano" preset (192Mi limit) OOM-killed redis in a tight loop
+  # (8,547 restarts). Redis holds Armada job events — give it real headroom.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi


### PR DESCRIPTION
Both `armada-redis` and `armada-postgresql` ran on bitnami's default `nano` resourcesPreset (192Mi memory limit), causing repeated OOM kills:

- `armada-redis-master-0` OOM-crashlooped — **8,547 restarts**, ~20s lifetime, exit 137
- `armada-postgresql-0` OOM-pressured — 16 restarts

These were cgroup memory-limit OOMs (`CONSTRAINT_MEMCG`), not host pressure (the host sits at ~7% RAM). This raises the limits in the values files:

- redis → **1Gi** (request 256Mi)
- postgres → **2Gi** (request 512Mi)

The live StatefulSets were already `kubectl patch`-ed to match; this brings the committed GitOps values back in sync so a future `armada/install.sh` reproduces it.
