### PR TITLE
jupyterhub: drop cpu_limit on singleuser profiles (let CPU burst)

### DIFF
--- a/jupyterhub/public-config.yaml
+++ b/jupyterhub/public-config.yaml
@@ -149,14 +149,12 @@ singleuser:
               kubespawner_override:
                 mem_guarantee: 8G
                 mem_limit: 8G
-                cpu_limit: 12
               default: true
             mem_16:
               display_name: 16 GB RAM
               kubespawner_override:
                 mem_guarantee: 16G
                 mem_limit: 16G
-                cpu_limit: 12
             mem_32:
               display_name: 32 GB RAM
               kubespawner_override:


### PR DESCRIPTION
Removes the `cpu_limit: 12` from the `mem_8` and `mem_16` singleuser profiles (the only two that had it; `mem_32`/`mem_64`/`special` already had none).

## Why
CPU is **compressible**, but a `cpu_limit` is enforced as a hard CFS quota — it throttles a pod even when the node is otherwise idle. Observed on a live notebook running a parallel RL sweep on the `mem_16` profile:

- pod capped at `cpu: 12` (request = limit)
- **throttled in 454,861 / 457,121 CFS periods (~99.5%)** while ~110 of the 128 host threads sat idle

Dropping the limit lets pods burst into idle cores; under contention the scheduler still shares CPU proportionally. **Memory limits are unchanged** (memory is incompressible and must stay capped).

## Notes
- No `cpu_guarantee` (request) is set — left as a follow-up decision; without it pods are CPU-BestEffort (burst freely, lowest priority under contention).
- Requires a hub `helm upgrade` to take effect, and **running pods keep their old limits until their owner restarts the server** (pod resources are immutable).
