### PR TITLE
jupyterhub: cap CPU math-library threads at 4 (prevent oversubscription)

### DIFF
--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -108,6 +108,33 @@ User pods automatically receive environment variables for MinIO access (via `Kub
 - `AWS_HTTPS: "true"`
 - `AWS_VIRTUAL_HOSTING: "FALSE"`
 
+#### CPU thread defaults (BLAS / OpenMP / PyTorch)
+
+User pods set `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, and
+`NUMEXPR_NUM_THREADS` to **`4`**. Numeric libraries otherwise spawn one thread per
+*visible host core* (128) **per process**, so running many jobs in parallel
+(grid searches, RL sweeps, `multiprocessing`/`joblib`) oversubscribes the CPU and
+thrashes — high load, low useful throughput, and it degrades the shared node for
+everyone. Capping at 4 keeps a single op reasonably fast while bounding the
+per-process multiplier under parallel workloads.
+
+**Override if you really want to lean on parallel BLAS** (e.g. one big single-process
+linear-algebra / scikit-learn job that should use many cores):
+
+```bash
+# shell, before launching python:
+export OMP_NUM_THREADS=16 OPENBLAS_NUM_THREADS=16 MKL_NUM_THREADS=16
+```
+```python
+# or inside a notebook (PyTorch), before the heavy work:
+import torch; torch.set_num_threads(16)
+```
+
+Conversely, when launching **many** parallel jobs yourself, set these to `1` so the
+total threads ≈ number of jobs (no oversubscription). There is no CPU limit on
+pods, so a single op can burst across all idle cores — these caps exist only to
+stop accidental thread-thrashing, not to restrict you.
+
 ### ARM64 Compatibility
 
 Nimbus is an ARM64 server.

--- a/jupyterhub/public-config.yaml
+++ b/jupyterhub/public-config.yaml
@@ -233,6 +233,16 @@ hub:
         AWS_VIRTUAL_HOSTING: "FALSE"
         GOOSE_PROVIDER: "github_copilot"
         OPENAI_BASE_URL: "https://ellm.nrp-nautilus.io/v1"
+        # CPU math-library thread caps. BLAS/OpenMP/PyTorch otherwise spawn one
+        # thread per visible host core (128) PER PROCESS, so many parallel jobs
+        # oversubscribe and thrash (context-switch + cache churn) — slow and
+        # antisocial on a shared node. Cap at 4: modest intra-op speedup, bounded
+        # multiplier under parallel sweeps. Override per-job for heavy parallel
+        # BLAS (e.g. `export OMP_NUM_THREADS=16` or `torch.set_num_threads(16)`).
+        OMP_NUM_THREADS: "4"
+        OPENBLAS_NUM_THREADS: "4"
+        MKL_NUM_THREADS: "4"
+        NUMEXPR_NUM_THREADS: "4"
       extra_pod_config:
         runtimeClassName: "nvidia"
     Authenticator:


### PR DESCRIPTION
Sets `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, and `NUMEXPR_NUM_THREADS` to **`4`** in the singleuser spawner environment (covers all profiles), and documents the override in the hub README.

## Why
Numeric libraries (BLAS/OpenMP/PyTorch) default to one thread per *visible host core* (128) **per process**. Running many parallel jobs (grid search, RL sweeps, `multiprocessing`/`joblib`) then oversubscribes the CPU — observed live: 16 parallel trainers spawned ~2,900 threads on 128 cores → context-switch/cache thrashing, high load, low useful throughput. With `cpu_limit` now removed (#28), a thrashing user can churn the whole shared node.

`4` is the compromise: a single op still gets some intra-op acceleration, while the per-process multiplier under parallel sweeps stays bounded (e.g. 16 jobs × 4 = 64 < 128).

## Override (documented in README)
- **Lean on parallel BLAS** (one big single-process job): `export OMP_NUM_THREADS=16 …` or `torch.set_num_threads(16)`.
- **Many parallel jobs**: set to `1` so total threads ≈ job count.

These caps only prevent accidental thrashing — there is no `cpu_limit`, so a single op can still burst across all idle cores.

## Notes
- Needs a hub `helm upgrade`; **running pods keep old env until their owner restarts** the server.
