### PR TITLE
feat(storage): scaffold JuiceFS RWX shared home storage (cirrus)

### DIFF
--- a/docs/content/docs/infrastructure/shared-home-storage.md
+++ b/docs/content/docs/infrastructure/shared-home-storage.md
@@ -64,12 +64,13 @@ This is **not** a replacement for ZFS:
 
 | Decision | Recommendation | Rationale |
 |---|---|---|
-| Object store | **RustFS** (Apache-2.0, S3-compatible) | Our chosen S3 backend now that MinIO is source-available. JuiceFS treats it as a generic S3 endpoint. |
+| Object store | **RustFS** (Apache-2.0, S3-compatible) | Our chosen S3 backend now that MinIO is source-available. JuiceFS treats it as a generic S3 endpoint. **Decoupled from the MinIO→RustFS migration:** we stand up a *dedicated* RustFS on `cirrus`/`tank` for the `juicefs-homes` bucket **now**, leaving the existing MinIO (`/mnt/nvme2,3` hostPath) fully untouched. Migrating MinIO's existing data to RustFS is a separate, later effort. |
 | Metadata engine | **PostgreSQL** (dedicated; *not* armada's) | The metadata DB *is* the filesystem — losing it orphans the data. Postgres gives ACID durability + trivial `pg_dump` backups. Redis is faster but loss-prone; revisit only if metadata ops bottleneck. |
 | S3 endpoint | **in-cluster** RustFS service, **path-style** | Keeps the data path on the cluster network (fast, no ingress/TLS hop). RustFS is MinIO-compatible → path-style addressing. |
 | Provisioning | **Dynamic** StorageClass, one subdir + **directory quota** per PVC | Mirrors today's `pvcNameTemplate`/quota model. |
 | CSI mode | **mount-pod** mode (default) | Decouples the mount from the app pod; restarting the CSI driver doesn't kill live sessions. |
-| Migration | **Additive + gradual** | Keep ZFS homes until each is migrated and verified; pilot on a throwaway user first. |
+| Migration | **Additive + gradual** | Keep ZFS homes until each is migrated and verified. |
+| Pilot axis | **Named servers**, *not* image/profile | A *named server* already gets its own fresh, separate home today, so "new named server → JuiceFS RWX home" matches existing behavior. The **default** server (everyone's existing populated home) stays on `openebs-zfs` and is never touched. Storage is deliberately **decoupled from image choice** so picking the GPU image for a default server does not hide a user's files. |
 
 ## Prerequisites (new stateful services — durability matters)
 
@@ -107,23 +108,35 @@ Homes will live here, so both backends need real durability:
    directory quota driven by the PVC's requested size. `openebs-zfs` is left
    untouched.
 
-5. **Repoint JupyterHub homes** (`jupyterhub/public-config.yaml`) — the only
-   change to existing config:
+5. **Route named servers to JuiceFS** (`jupyterhub/public-config.yaml`) — the
+   only change to existing config, and it is *additive*: the hub-wide default
+   stays `openebs-zfs`/RWO. A `pre_spawn_hook` switches storage **only for named
+   servers** (non-empty `spawner.name`); the default server is untouched:
    ```yaml
-   singleuser:
-     storage:
-       type: dynamic
-       capacity: 60Gi                 # becomes the JuiceFS directory quota
-       dynamic:
-         storageClass: juicefs-sc     # was: openebs-zfs
-         pvcNameTemplate: claim-{escaped_user_server}
-         storageAccessModes: [ReadWriteMany]   # was ReadWriteOnce
+   hub:
+     extraConfig:
+       10-juicefs-named-servers: |
+         def pre_spawn_hook(spawner):
+             # Named servers get a fresh RWX (node-mobile) home on JuiceFS.
+             # The default server (empty name) keeps openebs-zfs + RWO.
+             if spawner.name:
+                 spawner.storage_class = "juicefs-sc"
+                 spawner.storage_access_modes = ["ReadWriteMany"]
+         c.KubeSpawner.pre_spawn_hook = pre_spawn_hook
    ```
    Deploy with `cd jupyterhub && ./cirrus.sh`.
 
-   *Hybrid option:* instead of flipping the hub-wide default, set
-   `storageClass` per profile via `kubespawner_override` (e.g. a "thelio GPU"
-   profile uses `juicefs-sc` while the default stays `openebs-zfs`).
+   **Why named servers, not a profile/image option:** image choice
+   (`profileList`) is orthogonal to home storage — a user may run the GPU image
+   on their *default* server, and that server must keep its existing files.
+   Keying on `spawner.name` instead means storage never depends on the image.
+
+   **Safety property:** existing named-server PVCs (e.g. `claim-cboettig--test`)
+   are already bound to `openebs-zfs`; a bound PVC's `storageClass` is immutable
+   and kubespawner reuses an existing PVC rather than recreating it. So existing
+   named servers keep their data on ZFS — **only named servers created after
+   this change land on JuiceFS.** The pilot is exercised simply by spawning a
+   *new* named server.
 
 6. **Migrate existing homes** (per user, while their server is stopped): a
    one-shot pod mounts the old `openebs-zfs` PVC and the new JuiceFS PVC and
@@ -131,6 +144,39 @@ Homes will live here, so both backends need real durability:
 
 7. **Cutover & clean up.** Keep the old `openebs-zfs` PVCs until each user is
    verified on JuiceFS; delete them only afterward.
+
+## Sizing & future NVMe pool
+
+- **Size the RustFS data PVC generously up front (1Ti).** It is a thin/sparse
+  ZFS claim, so the number is a quota ceiling, not a reservation, and `tank` has
+  the headroom.
+- **Enable volume expansion.** The live `openebs-zfs` StorageClass has
+  `allowVolumeExpansion: false`, so a PVC can't be grown without recreating it.
+  Flip it to `true` (a mutable SC field; ZFS-LocalPV supports online expansion)
+  so future growth is a one-liner:
+  ```
+  kubectl patch sc openebs-zfs -p '{"allowVolumeExpansion": true}'
+  ```
+
+### When the new NVMe disks arrive
+
+Do **not** add the NVMe as general data vdevs to the SSD `tank`: ZFS stripes
+across all top-level vdevs (balanced by free space) and can't pin data to the
+fast vdev, so you'd get blended, unpredictable performance and couple the pool's
+redundancy across mismatched hardware. (The only sane "mix into one pool"
+patterns are accelerator roles — `special`/`log`/`cache` vdevs — but object
+*data* should live on the NVMe itself.)
+
+Instead, build a **separate dedicated NVMe pool** (with redundancy — e.g. 2×
+mirror vdevs or raidz1 across 4 disks; homes are precious). OpenEBS ZFS-LocalPV
+selects the pool **per-StorageClass** via the `poolname` parameter (the same
+mechanism behind `cirrus`/`tank` vs `thelio`/`openebs-zpool`), so the move is:
+
+1. Create the NVMe zpool, add a new SC (e.g. `openebs-nvme`, `poolname: nvme`).
+2. Stand a fresh RustFS PVC on `openebs-nvme` and `mc mirror` the bucket over.
+3. Cut the RustFS Deployment to the new PVC, **keeping the in-cluster Service
+   name and bucket stable** (`rustfs.rustfs.svc:9000` / `juicefs-homes`) so the
+   JuiceFS backend reference never changes.
 
 ## Validation (prove the friction is gone)
 

--- a/juicefs/README.md
+++ b/juicefs/README.md
@@ -1,0 +1,117 @@
+# JuiceFS shared (RWX) home storage — cirrus
+
+Multi-node, **ReadWriteMany** JupyterHub home dirs that are *not* node-pinned, so
+`/home/jovyan` follows a user to any node. Additive — `openebs-zfs` (ZFS LocalPV)
+stays the hub-wide default and is untouched.
+
+Full design + rationale: `docs/content/docs/infrastructure/shared-home-storage.md`.
+Tracking issue: #7.
+
+## Architecture
+
+```
+ JupyterHub NAMED-server pod (default server stays on openebs-zfs)
+        │  /home/jovyan   (RWX PVC from juicefs-sc, not node-pinned)
+        ▼
+ JuiceFS CSI driver  ── per-node mount pod (local read cache)
+        ├── metadata ──► PostgreSQL  (juicefs-pg, ns juicefs)   ← the file index
+        └── data ───────► RustFS S3  (rustfs.rustfs.svc:9000, bucket juicefs-homes)
+                          RustFS + Postgres PVCs both on cirrus/tank (openebs-zfs)
+```
+
+## Status: NOT yet deployed
+
+These manifests are scaffolding. Nothing here has been applied to the cluster.
+The existing MinIO (ns `minio`, `/mnt/nvme2,3`) is **untouched** by all of this.
+
+## Deploy order
+
+1. **Secrets.** Copy `credentials.example.yaml`, fill in real keys, apply (the
+   real copy must match the `*secret*.yaml` gitignore rule so it stays out of
+   git). Creates `rustfs-secrets`, `juicefs-pg`, `juicefs-secret`.
+
+2. **RustFS on cirrus/tank.**
+   ```
+   kubectl apply -f ../rustfs/cirrus.yaml
+   ```
+   Create the bucket `juicefs-homes` (via console at
+   `rustfs.cirrus.carlboettiger.info`, or `mc mb`).
+
+3. **Postgres metadata DB.**
+   ```
+   kubectl apply -f postgres.yaml
+   ```
+
+4. **Format the filesystem (one-time)** from a throwaway pod with the `juicefs`
+   binary (values must match `juicefs-secret`):
+   ```
+   juicefs format --storage s3 \
+     --bucket http://rustfs.rustfs.svc:9000/juicefs-homes \
+     --access-key <AK> --secret-key <SK> \
+     "postgres://juicefs:<PW>@juicefs-pg.juicefs.svc:5432/juicefs?sslmode=disable" \
+     jupyter-homes
+   ```
+   (The CSI driver can also auto-format on first mount when the secret carries
+   `metaurl`/`storage`/`bucket`/keys — explicit format is the safe path.)
+
+5. **Install the JuiceFS CSI driver** (Helm, mount-pod mode is the default):
+   ```
+   helm repo add juicefs https://juicedata.github.io/charts/ && helm repo update
+   helm upgrade -i juicefs-csi-driver juicefs/juicefs-csi-driver -n kube-system
+   ```
+   Then re-check the parameter/mountOption names in `storageclass.yaml` against
+   the installed chart version before applying it.
+
+6. **StorageClass.**
+   ```
+   kubectl apply -f storageclass.yaml
+   ```
+
+7. **Route named servers to JuiceFS.** Add to `jupyterhub/public-config.yaml`
+   under `hub:` (additive — default server stays openebs-zfs/RWO):
+   ```yaml
+   hub:
+     extraConfig:
+       10-juicefs-named-servers: |
+         def pre_spawn_hook(spawner):
+             if spawner.name:        # named server -> fresh RWX JuiceFS home
+                 spawner.storage_class = "juicefs-sc"
+                 spawner.storage_access_modes = ["ReadWriteMany"]
+         c.KubeSpawner.pre_spawn_hook = pre_spawn_hook
+   ```
+   Deploy: `cd ../jupyterhub && ./cirrus.sh`.
+
+   Existing named-server PVCs are already bound to `openebs-zfs` and are reused
+   as-is (storageClass is immutable on a bound PVC), so only **newly created**
+   named servers land on JuiceFS. Test by spawning a brand-new named server.
+
+## Recommended one-time tweak
+
+Enable PVC expansion on the ZFS class so RustFS/Postgres can grow without
+recreate (also eases the future NVMe-pool move):
+```
+kubectl patch sc openebs-zfs -p '{"allowVolumeExpansion": true}'
+```
+
+## Durability TODO before trusting real home data
+
+- **Postgres**: scheduled `pg_dump` (CronJob) and/or WAL archiving. Losing this
+  DB orphans all home data.
+- **RustFS**: it now holds home *data* — give it a backup target (e.g. `mc mirror`
+  to MinIO or off-cluster) and/or redundancy.
+
+## Validation
+
+1. Spawn a **new named server**, write a file, stop it.
+2. Confirm the PVC used `juicefs-sc` (`kubectl -n jupyter get pvc | grep juicefs`)
+   and the default server's home is still on `openebs-zfs`.
+3. When a second node serves users again (thelio repaired, or the arm64 DGX
+   Spark), force a spawn there and confirm `/home/jovyan` mounts with the file
+   present — proving the home is no longer node-pinned.
+
+## Migrating an existing default home to JuiceFS (later, per user, opt-in)
+
+While the user's server is stopped: a one-shot pod mounts the old `openebs-zfs`
+PVC and a new JuiceFS PVC and `rsync -aHAX /old/ /new/`. Keep the old PVC until
+verified. Rollback = revert the storage routing; nothing destructive until you
+delete the old PVC.

--- a/juicefs/credentials.example.yaml
+++ b/juicefs/credentials.example.yaml
@@ -1,0 +1,42 @@
+# EXAMPLE secrets — DO NOT COMMIT REAL CREDENTIALS. Copy, fill in, apply, and
+# keep the filled copy out of git. Three secrets are involved:
+#
+#   1. rustfs/rustfs-secrets   — RustFS root access/secret key (see rustfs/cirrus.yaml)
+#   2. juicefs/juicefs-pg      — Postgres password (see postgres.yaml)
+#   3. juicefs/juicefs-secret  — what the JuiceFS CSI driver reads to mount the FS
+#
+# The metaurl embeds the Postgres password; the JuiceFS CSI driver reads
+# `metaurl` + `storage`/`bucket`/`access-key`/`secret-key` from juicefs-secret.
+# The bucket URL points at the IN-CLUSTER RustFS service (no ingress hop).
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rustfs-secrets
+  namespace: rustfs
+stringData:
+  access-key: "CHANGE_ME_rustfs_access_key"
+  secret-key: "CHANGE_ME_rustfs_secret_key"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: juicefs-pg
+  namespace: juicefs
+stringData:
+  password: "CHANGE_ME_postgres_password"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: juicefs-secret
+  namespace: juicefs
+stringData:
+  name: "jupyter-homes"                       # JuiceFS filesystem name
+  storage: "s3"
+  bucket: "http://rustfs.rustfs.svc:9000/juicefs-homes"
+  access-key: "CHANGE_ME_rustfs_access_key"   # same as rustfs-secrets
+  secret-key: "CHANGE_ME_rustfs_secret_key"
+  # metaurl = the Postgres DSN. Password must match juicefs-pg above.
+  # sslmode=disable because it's in-cluster traffic.
+  metaurl: "postgres://juicefs:CHANGE_ME_postgres_password@juicefs-pg.juicefs.svc:5432/juicefs?sslmode=disable"

--- a/juicefs/postgres.yaml
+++ b/juicefs/postgres.yaml
@@ -1,0 +1,97 @@
+# Dedicated PostgreSQL for JuiceFS metadata (the file index IS the filesystem —
+# losing it orphans all home data). NOT armada's Postgres. Backed by cirrus/tank.
+#
+# This is a minimal single-instance deployment. BEFORE relying on it for real
+# home data, add durability: scheduled pg_dump and/or WAL archiving (see README).
+#
+# Secret `juicefs-pg` (key: password) must exist first — see credentials.example.yaml.
+#
+# NOTE: not yet applied. Apply with `kubectl apply -f juicefs/postgres.yaml`.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: juicefs
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: juicefs-pg-data
+  namespace: juicefs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-zfs   # cirrus tank
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: juicefs-pg
+  namespace: juicefs
+  labels:
+    app: juicefs-pg
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: juicefs-pg
+  strategy:
+    type: Recreate          # single node-local PVC; never run two pods on it
+  template:
+    metadata:
+      labels:
+        app: juicefs-pg
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: cirrus
+      containers:
+        - name: postgres
+          image: postgres:16
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_USER
+              value: juicefs
+            - name: POSTGRES_DB
+              value: juicefs
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: juicefs-pg
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "2Gi"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: juicefs-pg-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: juicefs-pg
+  namespace: juicefs
+  labels:
+    app: juicefs-pg
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+      name: postgres
+  selector:
+    app: juicefs-pg
+  type: ClusterIP

--- a/juicefs/storageclass.yaml
+++ b/juicefs/storageclass.yaml
@@ -1,0 +1,32 @@
+# JuiceFS dynamic StorageClass for ReadWriteMany, NOT node-pinned home dirs.
+# Additive: openebs-zfs is left untouched and stays the hub-wide default.
+#
+# Verify parameter/option names against the installed juicefs-csi-driver chart
+# version at deploy time (see README) — the CSI driver must be installed first.
+#
+# NOTE: not yet applied. Apply with `kubectl apply -f juicefs/storageclass.yaml`.
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: juicefs-sc
+provisioner: csi.juicefs.com
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  # Secret holding metaurl + S3 bucket/keys (see credentials.example.yaml).
+  csi.storage.k8s.io/provisioner-secret-name: juicefs-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: juicefs
+  csi.storage.k8s.io/node-publish-secret-name: juicefs-secret
+  csi.storage.k8s.io/node-publish-secret-namespace: juicefs
+  # One subdir per PVC, mirroring today's pvcNameTemplate model. The PVC's
+  # requested capacity is applied as a per-subdir directory quota.
+  pathPattern: "${.pvc.namespace}-${.pvc.name}"
+mountOptions:
+  # Per-node local read cache lives on each node's own disk (cirrus tank).
+  - cache-dir=/var/jfsCache
+  - cache-size=51200          # 50 GiB local cache ceiling
+  - writeback                 # async upload; trades some durability for speed on
+                              # write-heavy (conda/pip/.git) workloads. Reconsider
+                              # if you'd rather wait for confirmed uploads.

--- a/rustfs/cirrus.yaml
+++ b/rustfs/cirrus.yaml
@@ -1,0 +1,150 @@
+# RustFS on the ACTIVE cirrus cluster (distinct from the nimbus manifests in
+# this dir: init.yaml/deployment.yaml/service.yaml target s3.nimbus).
+#
+# Purpose: a dedicated, durable S3 backend on cirrus/tank (openebs-zfs) for the
+# JuiceFS `juicefs-homes` bucket — see docs/.../infrastructure/shared-home-storage.md.
+# This runs ALONGSIDE the existing MinIO (minio ns, /mnt/nvme2,3 hostPath), which
+# is left completely untouched. Migrating MinIO's existing data here is a separate,
+# later effort.
+#
+# Secret is NOT in this file. Create it first (see juicefs/credentials.example.yaml):
+#   kubectl -n rustfs create secret generic rustfs-secrets \
+#     --from-literal=access-key=<AK> --from-literal=secret-key=<SK>
+#
+# NOTE: not yet applied to the cluster. Apply with `kubectl apply -f rustfs/cirrus.yaml`.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rustfs
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rustfs-data
+  namespace: rustfs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-zfs   # cirrus `tank` (SSD). Thin/sparse: 1Ti is a ceiling.
+  resources:
+    requests:
+      storage: 1Ti
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rustfs
+  namespace: rustfs
+  labels:
+    app: rustfs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rustfs
+  # Single-replica store on a node-local ZFS PVC: Recreate avoids two pods
+  # racing the same /data during a rollout.
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: rustfs
+    spec:
+      # Pin to cirrus: the openebs-zfs PVC lives on cirrus `tank` and is
+      # node-local. (Matches MinIO/JupyterHub node placement.)
+      nodeSelector:
+        kubernetes.io/hostname: cirrus
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      containers:
+        - name: rustfs
+          image: rustfs/rustfs:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9000
+              name: api
+            - containerPort: 9001
+              name: console
+          env:
+            - name: RUSTFS_ADDRESS
+              value: ":9000"
+            - name: RUSTFS_CONSOLE_ENABLE
+              value: "true"
+            - name: RUSTFS_SERVER_DOMAINS
+              value: "s3.cirrus.carlboettiger.info"
+            - name: RUSTFS_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rustfs-secrets
+                  key: access-key
+            - name: RUSTFS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: rustfs-secrets
+                  key: secret-key
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2000m"
+              memory: "4Gi"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: rustfs-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustfs
+  namespace: rustfs
+  labels:
+    app: rustfs
+spec:
+  # JuiceFS reaches this purely in-cluster at rustfs.rustfs.svc:9000 — no
+  # ingress/TLS hop on the data path (see doc "S3 endpoint" decision).
+  ports:
+    - port: 9000
+      targetPort: 9000
+      name: api
+    - port: 9001
+      targetPort: 9001
+      name: console
+  selector:
+    app: rustfs
+  type: ClusterIP
+---
+# Ingress is OPTIONAL — only for browsing/testing RustFS externally while MinIO
+# is still live. The JuiceFS data path does NOT use it. Remove if undesired.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rustfs-console-ingress
+  namespace: rustfs
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - rustfs.cirrus.carlboettiger.info
+      secretName: rustfs-console-tls
+  rules:
+    - host: rustfs.cirrus.carlboettiger.info
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: rustfs
+                port:
+                  number: 9001


### PR DESCRIPTION
Scaffolds (does **not** deploy) node-mobile JupyterHub home dirs via JuiceFS, backed by a dedicated RustFS-on-`tank` S3 store and a dedicated PostgreSQL metadata DB. Purely **additive**: `openebs-zfs` stays the hub-wide default and the existing MinIO is left completely untouched.

## What this adds
- `rustfs/cirrus.yaml` — RustFS on cirrus/`tank` for the `juicefs-homes` bucket, distinct from the nimbus rustfs manifests; in-cluster Service for JuiceFS plus an optional console ingress for testing alongside live MinIO.
- `juicefs/` — Postgres metadata DB, `juicefs-sc` StorageClass, a credentials template (placeholders only), and a README with deploy order, one-time `format`, CSI install, durability TODOs, and validation.
- docs — records the design decisions below.

## Key decisions
- **Pilot on named servers, not image/profile.** A `pre_spawn_hook` keyed on `spawner.name` routes only **new** named servers to `juicefs-sc` (RWX, node-mobile). Default servers (everyone's existing populated home) stay on `openebs-zfs`. Storage is decoupled from image choice, so picking the GPU image on a default server never hides files. Existing named-server PVCs are reused as-is (bound PVC `storageClass` is immutable), so only newly-created named servers land on JuiceFS.
- **RustFS-on-tank now, decoupled from the MinIO→RustFS migration.** JuiceFS treats S3 as a generic backend, so the deferred migration of MinIO's existing data is independent and unblocked.
- **Sizing + expansion:** generous 1Ti RustFS PVC; doc notes flipping `allowVolumeExpansion` on `openebs-zfs` and the future separate-NVMe-pool migration path (per-SC `poolname`).

## Status
Nothing here is applied to the cluster. Durability hardening (Postgres `pg_dump`/WAL, RustFS backup) and verifying JuiceFS CSI parameter names against the installed chart version are called out as TODOs before real home data lands.

Refs #7