### PR TITLE
feat(storage): deploy JuiceFS RWX shared home storage (cirrus pilot)

### DIFF
--- a/docs/content/docs/infrastructure/shared-home-storage.md
+++ b/docs/content/docs/infrastructure/shared-home-storage.md
@@ -1,15 +1,32 @@
 ---
-title: "Shared Home Storage (Proposed)"
+title: "Shared Home Storage"
 weight: 10
 bookToc: true
 ---
 
-# Shared Home Storage for JupyterHub (Proposed)
+# Shared Home Storage for JupyterHub
 
-> **Status: PROPOSED — not yet deployed.** This is a design/plan document.
-> It is purely **additive**: it adds a new StorageClass alongside the existing
-> `openebs-zfs` (ZFS LocalPV). Nothing about the current ZFS storage is removed
-> or changed by adopting this.
+> **Status: DEPLOYED (pilot), 2026-06-28.** Live on `cirrus`: RustFS (`rustfs`
+> ns) + PostgreSQL + JuiceFS CSI driver `0.31.10` (`kube-system`) + the
+> `juicefs-sc` StorageClass. JupyterHub routes **new named servers** to JuiceFS;
+> default servers stay on `openebs-zfs`. Cross-node RWX (cirrus↔thelio) verified.
+> Purely **additive**: `openebs-zfs` (ZFS LocalPV) is unchanged, and the existing
+> MinIO is untouched.
+
+## Operational gotchas (hit during deploy)
+
+- **Do NOT set `RUSTFS_SERVER_DOMAINS`.** With it set, RustFS tries
+  virtual-hosted-style bucket parsing from the `Host` header, which breaks
+  path-style in-cluster access (`rustfs.rustfs.svc:9000`) — both `mc` and
+  JuiceFS fail with `InvalidBucketName`, and buckets appear not to persist.
+  Leave it unset; JuiceFS/`mc` use path-style.
+- **Raise `fs.inotify.max_user_instances` on every node running the CSI
+  driver.** The JuiceFS plugin watches its config via inotify; the kernel
+  default of `128` is exhausted on a busy control-plane node (`cirrus`), and the
+  plugin crash-loops with `fail to load config: too many open files`. Set to
+  `8192` (persisted in `/etc/sysctl.d/99-inotify-juicefs.conf` on `cirrus`).
+- **`juicefs format --storage s3`** works against RustFS once
+  `RUSTFS_SERVER_DOMAINS` is unset (the `minio` driver is not required).
 
 ## Problem
 

--- a/juicefs/README.md
+++ b/juicefs/README.md
@@ -19,10 +19,21 @@ Tracking issue: #7.
                           RustFS + Postgres PVCs both on cirrus/tank (openebs-zfs)
 ```
 
-## Status: NOT yet deployed
+## Status: DEPLOYED (pilot), 2026-06-28
 
-These manifests are scaffolding. Nothing here has been applied to the cluster.
-The existing MinIO (ns `minio`, `/mnt/nvme2,3`) is **untouched** by all of this.
+Live on `cirrus`: RustFS (`rustfs` ns), PostgreSQL + JuiceFS CSI driver
+`0.31.10`, `juicefs-sc`, and the named-server `pre_spawn_hook` in JupyterHub.
+Cross-node RWX (cirrus↔thelio) verified. The existing MinIO (ns `minio`,
+`/mnt/nvme2,3`) is **untouched**.
+
+### Two gotchas that bit us (don't repeat)
+
+- **RustFS: do NOT set `RUSTFS_SERVER_DOMAINS`** — it forces virtual-host bucket
+  parsing and breaks path-style in-cluster access (`InvalidBucketName`, buckets
+  seem not to persist). Left unset in `rustfs/cirrus.yaml`.
+- **Nodes need `fs.inotify.max_user_instances` raised** (default 128 is too low;
+  the CSI plugin crash-loops with `too many open files`). Set to `8192` on
+  `cirrus`, persisted in `/etc/sysctl.d/99-inotify-juicefs.conf`.
 
 ## Deploy order
 

--- a/jupyterhub/public-config.yaml
+++ b/jupyterhub/public-config.yaml
@@ -285,5 +285,15 @@ hub:
           'AWS_SECRET_ACCESS_KEY': os.environ.get('AWS_SECRET_ACCESS_KEY'),
           'OPENAI_API_KEY': os.environ.get('OPENAI_API_KEY'),
       })
+    # Route NAMED servers to JuiceFS (RWX, node-mobile homes); the default
+    # server keeps openebs-zfs/RWO untouched. See docs/.../shared-home-storage.md.
+    # Additive pilot: only named servers CREATED after this lands get juicefs-sc;
+    # existing bound PVCs are reused as-is (storageClass is immutable).
+    10-juicefs-named-servers: |
+      def pre_spawn_hook(spawner):
+          if spawner.name:
+              spawner.storage_class = "juicefs-sc"
+              spawner.storage_access_modes = ["ReadWriteMany"]
+      c.KubeSpawner.pre_spawn_hook = pre_spawn_hook
 
 

--- a/rustfs/cirrus.yaml
+++ b/rustfs/cirrus.yaml
@@ -26,10 +26,10 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: openebs-zfs   # cirrus `tank` (SSD). Thin/sparse: 1Ti is a ceiling.
+  storageClassName: openebs-zfs   # cirrus `tank` (SSD). Thin/sparse: ceiling, not a reservation.
   resources:
     requests:
-      storage: 1Ti
+      storage: 4Ti
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -74,8 +74,11 @@ spec:
               value: ":9000"
             - name: RUSTFS_CONSOLE_ENABLE
               value: "true"
-            - name: RUSTFS_SERVER_DOMAINS
-              value: "s3.cirrus.carlboettiger.info"
+            # NOTE: RUSTFS_SERVER_DOMAINS intentionally NOT set. Setting it makes
+            # RustFS attempt virtual-hosted-style bucket parsing from the Host
+            # header, which breaks path-style in-cluster access from JuiceFS
+            # (rustfs.rustfs.svc:9000) with InvalidBucketName. JuiceFS + mc both
+            # use path-style, so leave it unset.
             - name: RUSTFS_ACCESS_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Brings the JuiceFS shared-home stack **live on cirrus** and records the deploy-time fixes. Builds on #32. Additive: `openebs-zfs` stays the hub default and the existing MinIO is untouched.

## Now live on cirrus
- RustFS on `tank` (`rustfs` ns), data PVC 4Ti
- PostgreSQL metadata DB (`juicefs` ns)
- JuiceFS CSI driver `0.31.10` (`kube-system`), mount-pod mode
- `juicefs-sc` StorageClass (RWX, per-PVC subdir+quota)
- JupyterHub `pre_spawn_hook`: **new named servers → `juicefs-sc`**; default servers stay on `openebs-zfs`

## Deploy-time fixes captured here
- **Dropped `RUSTFS_SERVER_DOMAINS`** — with it set, RustFS does virtual-host bucket parsing from the `Host` header and path-style in-cluster access fails (`mc`/JuiceFS get `InvalidBucketName`; buckets appear not to persist). Unset → path-style works.
- **`fs.inotify.max_user_instances` 128→8192** on cirrus — the CSI plugin watches config via inotify and crash-loops with `too many open files` at the kernel default. Persisted in `/etc/sysctl.d/99-inotify-juicefs.conf`.
- `juicefs format --storage s3` works against RustFS once the above is fixed (no need for the `minio` driver).

## Validation
- Dynamic RWX PVC provisioned and bound (`juicefs-sc`)
- Two pods on **different nodes** (cirrus + cordoned thelio) shared a file bidirectionally
- Writes confirmed as objects in the RustFS `juicefs-homes` bucket

Real home data durability hardening (Postgres `pg_dump`/WAL, RustFS backup) remains a follow-up before wide rollout.

Refs #7