### PR TITLE
feat(juicefs): node inotify tuning + metadata DB backups; pin CSI version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ hugo_extended_*.tar.gz
 # Local-only ops/maintenance journal (drive serials, host topology, security posture)
 /ops/
 
+
+# Local-only secret material (import to Bitwarden, never commit)
+/secrets/

--- a/juicefs/README.md
+++ b/juicefs/README.md
@@ -65,20 +65,29 @@ Cross-node RWX (cirrus↔thelio) verified. The existing MinIO (ns `minio`,
    (The CSI driver can also auto-format on first mount when the secret carries
    `metaurl`/`storage`/`bucket`/keys — explicit format is the safe path.)
 
-5. **Install the JuiceFS CSI driver** (Helm, mount-pod mode is the default):
+5. **Node prerequisite:** raise `fs.inotify.max_user_instances` (default 128 is
+   too low; the CSI plugin crash-loops with `too many open files`). Apply the
+   DaemonSet that sets it to 8192 on every node:
+   ```
+   kubectl apply -f node-inotify.yaml
+   ```
+
+6. **Install the JuiceFS CSI driver** (Helm, mount-pod mode is the default).
+   Pin the chart version we deployed for reproducibility:
    ```
    helm repo add juicefs https://juicedata.github.io/charts/ && helm repo update
-   helm upgrade -i juicefs-csi-driver juicefs/juicefs-csi-driver -n kube-system
+   helm upgrade -i juicefs-csi-driver juicefs/juicefs-csi-driver \
+     -n kube-system --version 0.31.10
    ```
-   Then re-check the parameter/mountOption names in `storageclass.yaml` against
-   the installed chart version before applying it.
+   If you bump the version, re-check the parameter/mountOption names in
+   `storageclass.yaml` against the new chart.
 
-6. **StorageClass.**
+7. **StorageClass.**
    ```
    kubectl apply -f storageclass.yaml
    ```
 
-7. **Route named servers to JuiceFS.** Add to `jupyterhub/public-config.yaml`
+8. **Route named servers to JuiceFS.** Add to `jupyterhub/public-config.yaml`
    under `hub:` (additive — default server stays openebs-zfs/RWO):
    ```yaml
    hub:

--- a/juicefs/node-inotify.yaml
+++ b/juicefs/node-inotify.yaml
@@ -1,0 +1,51 @@
+# Node tuning for the JuiceFS CSI driver.
+#
+# The JuiceFS CSI plugin watches its config via inotify. The kernel default
+# fs.inotify.max_user_instances=128 is exhausted on a busy control-plane node
+# (cirrus), so the plugin crash-loops with "fail to load config: too many open
+# files". This DaemonSet raises it to 8192 on EVERY node (live + persisted),
+# and re-applies on reboot/reschedule. tolerations: Exists so it also covers
+# cordoned (thelio) and future tainted GPU nodes (DGX Spark).
+#
+# Apply: kubectl apply -f juicefs/node-inotify.yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-inotify-tuning
+  namespace: kube-system
+  labels:
+    app: node-inotify-tuning
+spec:
+  selector:
+    matchLabels:
+      app: node-inotify-tuning
+  template:
+    metadata:
+      labels:
+        app: node-inotify-tuning
+    spec:
+      hostPID: true
+      # Run on all nodes, including cordoned/tainted ones.
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: sysctl
+          image: alpine:3.20
+          securityContext:
+            privileged: true
+          # Enter the host namespaces (pid 1) to set + persist the host sysctl,
+          # then idle (DaemonSets require a long-running container).
+          command: ["nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid", "--", "sh", "-c"]
+          args:
+            - |
+              sysctl -w fs.inotify.max_user_instances=8192
+              printf 'fs.inotify.max_user_instances=8192\n' > /etc/sysctl.d/99-inotify-juicefs.conf
+              echo "node $(hostname): fs.inotify.max_user_instances=$(sysctl -n fs.inotify.max_user_instances)"
+              sleep infinity
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 32Mi

--- a/juicefs/pg-backup.yaml
+++ b/juicefs/pg-backup.yaml
@@ -1,0 +1,78 @@
+# Nightly backup of the JuiceFS metadata DB.
+#
+# WHY THIS MATTERS: in JuiceFS, this Postgres DB *is* the filesystem index — it
+# maps every file/dir/inode to the chunk objects in RustFS. The chunk bytes in
+# RustFS are meaningless without it. Lose this DB and EVERY home dir becomes
+# unrecoverable, even though the data still sits in RustFS. So we snapshot it.
+#
+# This dumps to a dedicated PVC on cirrus/tank. That protects against DB
+# corruption / bad migration / accidental drop. It does NOT protect against loss
+# of the tank pool itself — FOLLOW-UP: mirror these dumps off-cluster (e.g.
+# `mc mirror` the backups to an off-site S3, or restic to another host).
+#
+# (Alternative engine-agnostic approach: `juicefs dump` exports metadata to a
+# portable JSON image restorable with `juicefs load`. We use pg_dump here.)
+#
+# Apply: kubectl apply -f juicefs/pg-backup.yaml
+# Restore: gunzip -c <dump>.sql.gz | psql -h juicefs-pg.juicefs.svc -U juicefs -d juicefs
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: juicefs-pg-backup
+  namespace: juicefs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-zfs
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: juicefs-pg-backup
+  namespace: juicefs
+spec:
+  schedule: "17 4 * * *"          # nightly 04:17
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          nodeSelector:
+            kubernetes.io/hostname: cirrus
+          containers:
+            - name: pg-dump
+              image: postgres:16          # match the server major version
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: juicefs-pg
+                      key: password
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -euo pipefail
+                  ts=$(date -u +%Y%m%d-%H%M%S)
+                  out="/backup/juicefs-meta-${ts}.sql.gz"
+                  echo "dumping metadata DB -> ${out}"
+                  pg_dump -h juicefs-pg.juicefs.svc -U juicefs -d juicefs \
+                    | gzip > "${out}"
+                  echo "size: $(du -h "${out}" | cut -f1)"
+                  # retain last 14 days
+                  find /backup -name 'juicefs-meta-*.sql.gz' -mtime +14 -delete
+                  echo "current backups:"; ls -lh /backup
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+          volumes:
+            - name: backup
+              persistentVolumeClaim:
+                claimName: juicefs-pg-backup


### PR DESCRIPTION
Closes the reproducibility/durability gaps from the cirrus pilot (builds on #32, #33).

- **`juicefs/node-inotify.yaml`** — DaemonSet raising `fs.inotify.max_user_instances` to 8192 on every node (live + persisted to `/etc/sysctl.d`, tolerates cordon/taints). Makes the host fix reproducible and auto-covers future nodes (DGX Spark). Verified: reports 8192 on both cirrus and thelio.
- **`juicefs/pg-backup.yaml`** — nightly `pg_dump` CronJob + dedicated 10Gi backup PVC, 14-day retention. The Postgres metadata DB *is* the filesystem index (maps files → RustFS chunks); losing it orphans all home data even though the bytes survive — so this is the key durability measure. Verified with a manual test run (dump written to the backup PVC). Off-cluster mirroring of the dumps remains a follow-up.
- **`juicefs/README.md`** — pin CSI chart to `0.31.10`; add the inotify prereq step.
- **`.gitignore`** — ignore `/secrets/` (local-only credential material for Bitwarden import; never committed).

Refs #7