### PR TITLE
monitoring: Prometheus + dcgm-exporter for nimbus GPU/vLLM metrics

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -15,3 +15,10 @@ Feeds GPU power and vLLM token metrics to `nimbus-carbon-api`
     curl -s 'http://localhost:9090/api/v1/query?query=up' | python3 -m json.tool
 
 Prometheus URL in-cluster: `http://prometheus-server.monitoring.svc.cluster.local`
+
+## Metrics
+
+- `DCGM_FI_DEV_POWER_USAGE` — GPU power draw in watts (from dcgm-exporter).
+  Note: on GB10's unified-memory architecture, `DCGM_FI_DEV_FB_FREE` /
+  `DCGM_FI_DEV_FB_USED` and memory-clock fields report `N/A` — expected,
+  not a bug.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,17 @@
+# nimbus monitoring
+
+Minimal Prometheus + dcgm-exporter stack for nimbus (single GB10 node).
+Feeds GPU power and vLLM token metrics to `nimbus-carbon-api`
+(see `boettiger-lab/nimbus-carbon-api` and
+`docs/superpowers/specs/2026-07-04-nimbus-carbon-api-design.md`).
+
+## Install
+
+    cd monitoring && ./install.sh
+
+## Query
+
+    kubectl -n monitoring port-forward svc/prometheus-server 9090:80
+    curl -s 'http://localhost:9090/api/v1/query?query=up' | python3 -m json.tool
+
+Prometheus URL in-cluster: `http://prometheus-server.monitoring.svc.cluster.local`

--- a/monitoring/dcgm-exporter-values.yaml
+++ b/monitoring/dcgm-exporter-values.yaml
@@ -1,0 +1,16 @@
+# dcgm-exporter on nimbus's single GB10. Must NOT request nvidia.com/gpu —
+# that resource is time-sliced 8-way for model-serving pods
+# (see ../nvidia/nvidia-device-plugin-config.yaml). GPU access instead
+# comes from runtimeClassName, same mechanism deploy-qwen.yaml uses.
+runtimeClassName: nvidia
+
+# No prometheus-operator CRDs installed in this cluster — ServiceMonitor
+# would fail to apply.
+serviceMonitor:
+  enabled: false
+
+# Picked up by Prometheus's built-in kubernetes-pods scrape job
+# (enabled by default in the prometheus-community/prometheus chart).
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "9400"

--- a/monitoring/install.sh
+++ b/monitoring/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add gpu-helm-charts https://nvidia.github.io/dcgm-exporter/helm-charts
+helm repo update
+
+helm upgrade -i prometheus prometheus-community/prometheus \
+  --namespace monitoring \
+  --create-namespace \
+  --version 29.14.0 \
+  --wait \
+  --values prometheus-values.yaml

--- a/monitoring/install.sh
+++ b/monitoring/install.sh
@@ -11,3 +11,9 @@ helm upgrade -i prometheus prometheus-community/prometheus \
   --version 29.14.0 \
   --wait \
   --values prometheus-values.yaml
+
+helm upgrade -i dcgm-exporter gpu-helm-charts/dcgm-exporter \
+  --namespace monitoring \
+  --version 4.8.2 \
+  --wait \
+  --values dcgm-exporter-values.yaml

--- a/monitoring/prometheus-values.yaml
+++ b/monitoring/prometheus-values.yaml
@@ -1,0 +1,18 @@
+# Minimal Prometheus install for nimbus: just prometheus-server.
+# No Alertmanager, kube-state-metrics, node-exporter, or Pushgateway —
+# this cluster only needs Prometheus as a metrics store for dcgm-exporter
+# and vLLM's built-in /metrics endpoint.
+alertmanager:
+  enabled: false
+kube-state-metrics:
+  enabled: false
+prometheus-node-exporter:
+  enabled: false
+prometheus-pushgateway:
+  enabled: false
+
+server:
+  retention: "15d"
+  persistentVolume:
+    storageClass: openebs-zfs
+    size: 5Gi

--- a/vllm/nimbus/service.yaml
+++ b/vllm/nimbus/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: vllm-nimbus-service
   labels:
     k8s-app: vllm-nimbus
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8000"
 
 spec:
   type: LoadBalancer


### PR DESCRIPTION
## Summary
- Deploys a minimal Prometheus (no Alertmanager/kube-state-metrics/node-exporter/pushgateway) into a new `monitoring` namespace
- Deploys dcgm-exporter as a single-replica component reading GB10 GPU power via DCGM, without requesting the `nvidia.com/gpu` extended resource (so it doesn't compete with the 8 time-sliced replicas used by model-serving pods)
- Exposes the existing `vllm-nimbus-service` to Prometheus via scrape annotations

This is the first of two plans implementing the [nimbus-carbon-api design](https://github.com/boettiger-lab/k8s/blob/nimbus/monitoring-infra/docs/superpowers/specs/2026-07-04-nimbus-carbon-api-design.md) (a carbon-footprint dashboard/API mirroring `nrp-carbon-api`, scoped to nimbus's single GB10). The second plan (forking nrp-carbon-api into a new `nimbus-carbon-api` service) depends on this infra and hasn't been written yet.

Confirmed live on the cluster: `DCGM_FI_DEV_POWER_USAGE` (~11W) and `vllm:generation_tokens_total` (labeled `model_name="qwen"`) are both queryable in Prometheus.

## Test plan
- [x] Prometheus pod Running (2/2), self-scrape target up
- [x] dcgm-exporter pod Running (1/1), `DCGM_FI_DEV_POWER_USAGE` visible on its `/metrics` and in Prometheus
- [x] vLLM service annotated; `vllm:generation_tokens_total` visible in Prometheus with `model_name="qwen"`
- [x] No Ingress created for either component (internal-only, per design)
- [x] No `nvidia.com/gpu` resource requested by dcgm-exporter (verified against chart defaults + rendered manifest)
- [x] Task-level and final whole-branch subagent reviews both clean (no Critical/Important findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)