### PR TITLE
monitoring: cirrus carbon/perf dashboard (carbon-cirrus.carlboettiger.info)

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,13 +1,37 @@
-# nimbus monitoring
+# monitoring
 
-Minimal Prometheus + dcgm-exporter stack for nimbus (single GB10 node).
-Feeds GPU power and vLLM token metrics to `nimbus-carbon-api`
-(see `boettiger-lab/nimbus-carbon-api` and
-`docs/superpowers/specs/2026-07-04-nimbus-carbon-api-design.md`).
+Minimal Prometheus + dcgm-exporter stack that feeds GPU power and vLLM token
+metrics to a carbon/performance dashboard. The same charts + values apply to
+each cluster (they are cluster-agnostic); the carbon-api on top is configured
+per node.
+
+- **nimbus** (single GB10): `nimbus-carbon-api` (see
+  `boettiger-lab/nimbus-carbon-api` and
+  `docs/superpowers/specs/2026-07-04-nimbus-carbon-api-design.md`),
+  live at <https://carbon-nimbus.carlboettiger.info>.
+- **cirrus** (two RTX 8000s, time-sliced across vllm/jupyter/mcp):
+  `cirrus-carbon-api.yaml` in this directory, live at
+  <https://carbon-cirrus.carlboettiger.info>. It runs the *same* image, just
+  parameterized by env (`NAMESPACE=vllm`, `NODE_NAME=cirrus`, `GPU_COUNT=2`,
+  `NODE_POWER=true`).
 
 ## Install
 
-    cd monitoring && ./install.sh
+    cd monitoring && ./install.sh          # Prometheus + dcgm-exporter (per cluster)
+    kubectl apply -f cirrus-carbon-api.yaml # cirrus only: the dashboard
+
+The cirrus dashboard also needs the `prometheus.io/scrape` annotations on
+`vllm-qwen3-6-service` (see `../vllm/cirrus/deploy-qwen3-6.yaml`) so Prometheus
+scrapes vLLM's `/metrics`.
+
+## Shared-GPU power attribution (cirrus)
+
+cirrus has two physical GPUs time-sliced across several namespaces, so DCGM
+per-GPU power cannot be split per tenant. `cirrus-carbon-api` runs with
+`NODE_POWER=true`: it sums **total node GPU power** and attributes it to the
+vLLM namespace as an explicit upper bound (the API/dashboard flag this via
+`power_is_node_total=true`). nimbus (one GPU, one model at a time) does not
+need this.
 
 ## Query
 

--- a/monitoring/cirrus-carbon-api.yaml
+++ b/monitoring/cirrus-carbon-api.yaml
@@ -1,0 +1,106 @@
+# Carbon/performance dashboard for the cirrus vLLM model, mirroring the nimbus
+# one (carbon-nimbus.carlboettiger.info). Same image as nimbus
+# (ghcr.io/boettiger-lab/nimbus-carbon-api) — it is parameterized per node by
+# env. cirrus differs from nimbus in two ways, both handled via env below:
+#   - vLLM runs in the "vllm" namespace (nimbus uses "default").
+#   - cirrus has TWO RTX 8000s, time-sliced across vllm/jupyter/mcp, so DCGM
+#     per-GPU power can't be attributed per tenant. NODE_POWER=true sums total
+#     node GPU power and attributes it to the vLLM namespace as an upper bound
+#     (the API/dashboard flag this via power_is_node_total=true).
+#
+# Requires the monitoring stack (Prometheus + dcgm-exporter) from ./install.sh
+# and the prometheus.io/scrape annotations on vllm-qwen3-6-service.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cirrus-carbon-api
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cirrus-carbon-api
+  template:
+    metadata:
+      labels:
+        app: cirrus-carbon-api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: cirrus-carbon-api
+          image: ghcr.io/boettiger-lab/nimbus-carbon-api:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+            - name: PROMETHEUS_URL
+              value: "http://prometheus-server.monitoring.svc.cluster.local"
+            - name: SCRAPE_INTERVAL
+              value: "30s"
+            - name: LISTEN_ADDR
+              value: ":8080"
+            - name: NAMESPACE
+              value: "vllm"
+            - name: NODE_NAME
+              value: "cirrus"
+            - name: GPU_HARDWARE
+              value: "Quadro RTX 8000"
+            - name: GPU_COUNT
+              value: "2"
+            - name: NODE_POWER
+              value: "true"
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cirrus-carbon-api
+  namespace: monitoring
+spec:
+  selector:
+    app: cirrus-carbon-api
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cirrus-carbon-api
+  namespace: monitoring
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+  labels:
+    app: cirrus-carbon-api
+spec:
+  ingressClassName: traefik
+  rules:
+  - host: carbon-cirrus.carlboettiger.info
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: cirrus-carbon-api
+            port:
+              number: 80
+  tls:
+  - hosts:
+    - carbon-cirrus.carlboettiger.info
+    secretName: cirrus-carbon-api-tls

--- a/vllm/cirrus/deploy-qwen3-6.yaml
+++ b/vllm/cirrus/deploy-qwen3-6.yaml
@@ -106,6 +106,13 @@ metadata:
   namespace: vllm
   labels:
     k8s-app: vllm-cirrus-qwen3-6
+  annotations:
+    # Scraped by the monitoring stack's Prometheus (kubernetes-service-endpoints
+    # job) for the carbon/perf dashboard at carbon-cirrus.carlboettiger.info.
+    # vLLM's /metrics is unauthenticated. See ../../monitoring/.
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8000"
+    prometheus.io/path: "/metrics"
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
Mirrors the nimbus carbon dashboard for the cirrus vLLM model. **Live now** at <https://carbon-cirrus.carlboettiger.info>.

## Architecture (same as nimbus)
`dcgm-exporter` (GPU watts) + vLLM `/metrics` (tokens) → Prometheus → carbon-api → dashboard. Prometheus + dcgm-exporter deployed on cirrus via `monitoring/install.sh`.

## What is cirrus-specific
Same image as nimbus (`ghcr.io/boettiger-lab/nimbus-carbon-api`, now env-parameterized — see that repo's PRs #1–#4), configured via env:
- `NAMESPACE=vllm` (nimbus uses `default`)
- `NODE_NAME=cirrus`, `GPU_HARDWARE="Quadro RTX 8000"`, `GPU_COUNT=2`
- `NODE_POWER=true` — cirrus has **two** RTX 8000s time-sliced across vllm/jupyter/mcp, so DCGM per-GPU power can't be attributed per tenant. This sums total node GPU power and attributes it to vLLM as an explicit upper bound (`power_is_node_total=true`).

## Notable
The dashboard reports **actual decode speed** (`rate(generation_tokens)/rate(inter_token_latency_sum)` ≈ 140 tok/s), not the idle-diluted wall-clock token rate.

## Files
- `monitoring/cirrus-carbon-api.yaml` — Deployment + Service + Ingress
- `vllm/cirrus/deploy-qwen3-6.yaml` — `prometheus.io/scrape` annotations on the Service
- `monitoring/README.md` — per-cluster usage + shared-GPU attribution note

Verified live: cert issued, DNS resolving, API returns node=cirrus / 2× RTX 8000 / decode ~140 tok/s under load.