### PR TITLE
Fix Prometheus cardinality blowup; remove privileged dind from all ARC runners

### DIFF
--- a/github-actions/cirrus-efi-hook-template.yaml
+++ b/github-actions/cirrus-efi-hook-template.yaml
@@ -56,7 +56,14 @@ data:
             # explicitly. Allowed under PodSecurity "baseline" (only "restricted"
             # forbids running as root), which is the level this namespace uses.
             runAsUser: 0
+            # privileged:false is the setting that actually matters — it is what
+            # removes the dind escape path to the node.
             allowPrivilegeEscalation: false
             privileged: false
-            capabilities:
-              drop: ["ALL"]
+            # Deliberately NOT `capabilities: drop: [ALL]`. The runner container
+            # runs as uid 1001 and creates _work/_temp owned by 1001; the job
+            # container is uid 0 and relies on CAP_DAC_OVERRIDE to write there.
+            # Dropping ALL revokes it, and every job dies at the first action with
+            #   EACCES: permission denied, open '/__w/_temp/_runner_file_commands/...'
+            # (confirmed by testing). The default capability set is what the old
+            # `--user root` dind container had anyway, and it excludes CAP_SYS_ADMIN.

--- a/github-actions/cirrus-efi-hook-template.yaml
+++ b/github-actions/cirrus-efi-hook-template.yaml
@@ -1,0 +1,62 @@
+# Hook pod template for the efi-cirrus runner scale set (containerMode: kubernetes).
+#
+# Under kubernetes mode, each workflow `container:` runs as its own pod, created
+# by actions/runner-container-hooks rather than by a Docker daemon. This file is
+# the hook's "extension": it is merged into the generated job pod, and is where
+# the settings that used to live in the workflows' `options:` field now live.
+#
+# `$job` is not a placeholder we invented — the hooks target the job container by
+# the literal name CONTAINER_EXTENSION_PREFIX ("$") + JOB_CONTAINER_NAME ("job").
+# The merge protects `name` and `image` (a template cannot swap the workflow's
+# image) but OVERWRITES `resources` and `securityContext`, which is precisely
+# what we want here.
+#
+# Replaces, for every job on this scale set:
+#   options: --memory 45g   ->  resources.limits.memory (neon4cast-ci)
+#   options: --memory 40g   ->  resources.limits.memory (usgsrc4cast-ci)
+#   options: --user root    ->  securityContext.runAsUser: 0  (scoring.yaml)
+#
+# NOTE this template is per-scale-set, not per-workflow, so the old 45g/40g split
+# collapses to a single ceiling. 45Gi is used (the higher of the two) to match
+# the limit the neon4cast-ci README calls out as important. This is a stricter
+# guarantee than the old Docker flag: `--memory` was invisible to the scheduler,
+# whereas a pod limit is both enforced by the kubelet and accounted for when
+# placing the pod.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: efi-cirrus-hook-template
+  namespace: arc-runners
+data:
+  default.yaml: |
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      name: efi-cirrus-job-pod
+    spec:
+      # The kube-mode ServiceAccount the chart generates holds
+      # secrets: [get, list, create, delete] in arc-runners — the namespace that
+      # also holds github-runner-token (the PAT). Workflow steps execute in THIS
+      # pod, so denying the token projection here stops a job from using that
+      # RBAC to read the PAT via the API server. The runner container keeps its
+      # token; it is the one that legitimately needs to create job pods.
+      automountServiceAccountToken: false
+      containers:
+        - name: $job
+          resources:
+            requests:
+              # Keep the request small so two runners can always be scheduled;
+              # the limit is the real guard against a runaway R process.
+              memory: 2Gi
+              cpu: 500m
+            limits:
+              memory: 45Gi
+          securityContext:
+            # rocker images expect root; scoring.yaml used `options: --user root`
+            # explicitly. Allowed under PodSecurity "baseline" (only "restricted"
+            # forbids running as root), which is the level this namespace uses.
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            privileged: false
+            capabilities:
+              drop: ["ALL"]

--- a/github-actions/cirrus-efi-values.yaml
+++ b/github-actions/cirrus-efi-values.yaml
@@ -1,6 +1,12 @@
 githubConfigUrl: "https://github.com/eco4cast"
 githubConfigSecret: github-runner-token
-maxRunners: 1
+# 2, not 1: this scale set now serves BOTH eco4cast/usgsrc4cast-ci and
+# eco4cast/neon4cast-ci, after the redundant arc-runner-eco4cast set was
+# consolidated into it. Those two repos both fire a job at 23:00 UTC
+# (usgsrc4cast drivers_stage1 and neon4cast drivers_stage3), which used to run
+# concurrently on two separate scale sets. maxRunners: 2 keeps that concurrency
+# identical — do not drop it back to 1 or the 23:00 jobs will serialize.
+maxRunners: 2
 runnerGroup: "default"
 
 ## Container mode is an object that provides out-of-box configuration

--- a/github-actions/cirrus-efi-values.yaml
+++ b/github-actions/cirrus-efi-values.yaml
@@ -1,6 +1,6 @@
 githubConfigUrl: "https://github.com/eco4cast"
 githubConfigSecret: github-runner-token
-# 2, not 1: this scale set now serves BOTH eco4cast/usgsrc4cast-ci and
+# 2, not 1: this scale set serves BOTH eco4cast/usgsrc4cast-ci and
 # eco4cast/neon4cast-ci, after the redundant arc-runner-eco4cast set was
 # consolidated into it. Those two repos both fire a job at 23:00 UTC
 # (usgsrc4cast drivers_stage1 and neon4cast drivers_stage3), which used to run
@@ -9,71 +9,55 @@ githubConfigSecret: github-runner-token
 maxRunners: 2
 runnerGroup: "default"
 
-## Container mode is an object that provides out-of-box configuration
-## for dind and kubernetes mode. Template will be modified as documented under the
-## template object.
-##
-## If any customization is required for dind or kubernetes mode, containerMode should remain
-## empty, and configuration should be applied to the template.
-#containerMode:
-#  type: "dind"  ## type can be set to dind or kubernetes
-## template is the PodSpec for each runner Pod
-## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+# containerMode: kubernetes — job containers run as sibling PODS, created by
+# actions/runner-container-hooks, instead of by a Docker daemon inside the runner.
+#
+# This replaces the previous hand-written dind template, which ran
+# `docker:dind` with securityContext.privileged: true and shared /var/run with
+# the runner container. That gave every workflow job a privileged Docker socket,
+# i.e. a straight path to root on cirrus — which since thelio was decommissioned
+# is the cluster's only node and its control plane. Removing dind closes that.
+#
+# Constraints this imposes on the workflows (all five current jobs comply):
+#   - every job on this runner MUST specify `container:` (jobs without one fail)
+#   - `options:` is NOT supported — see cirrus-efi-hook-template.yaml, which is
+#     where the old --memory/--user settings moved to
+#   - no docker CLI in steps, and no building container actions from a Dockerfile
+# ref https://github.com/actions/runner-container-hooks/blob/main/packages/k8s/README.md
+containerMode:
+  type: "kubernetes"
+  kubernetesModeWorkVolumeClaim:
+    # MUST be RWX: the runner pod and each job pod both mount _work.
+    # juicefs-sc is the only RWX class here — openebs-zfs is node-local RWO.
+    accessModes: ["ReadWriteMany"]
+    storageClassName: "juicefs-sc"
+    resources:
+      requests:
+        storage: 100Gi
+
 template:
-  ## template.spec will be modified if you change the container mode
-  ## with containerMode.type=dind, we will populate the template.spec with following pod spec
-     spec:
-       initContainers:
-       - name: init-dind-externals
-         image: ghcr.io/actions/actions-runner:latest
-         command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
-         volumeMounts:
-           - name: dind-externals
-             mountPath: /home/runner/tmpDir
-       containers:
-       - name: runner
-         image: ghcr.io/actions/actions-runner:latest
-         command: ["/home/runner/run.sh"]
-         resources: 
-           requests:
-             memory: "1Gi"
-           limits:
-             memory: "40Gi"
-         env:
-           - name: DOCKER_HOST
-             value: unix:///var/run/docker.sock
-         volumeMounts:
-           - name: work
-             mountPath: /home/runner/_work
-           - name: dind-sock
-             mountPath: /var/run
-       - name: dind
-         image: docker:dind
-         resources: 
-           requests:
-             memory: "1Gi"
-           limits:
-             memory: "40Gi"
-         args:
-           - dockerd
-           - --host=unix:///var/run/docker.sock
-           - --group=$(DOCKER_GROUP_GID)
-         env:
-           - name: DOCKER_GROUP_GID
-             value: "123"
-         securityContext:
-           privileged: true
-         volumeMounts:
-           - name: work
-             mountPath: /home/runner/_work
-           - name: dind-sock
-             mountPath: /var/run
-           - name: dind-externals
-             mountPath: /home/runner/externals
-       volumes:
-       - name: work
-         emptyDir: {}
-       - name: dind-sock
-         emptyDir: {}
-       - name: dind-externals
-         emptyDir: {}
+  spec:
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          # Points the hooks at the merged job-pod spec (the ConfigMap).
+          - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+            value: /home/runner/pod-templates/default.yaml
+        volumeMounts:
+          - name: pod-templates
+            mountPath: /home/runner/pod-templates
+            readOnly: true
+        resources:
+          requests:
+            memory: 1Gi
+          limits:
+            # The runner container only orchestrates now — the heavy R work
+            # happens in the job pod, which is capped separately in the hook
+            # template. It no longer needs the old 40Gi ceiling.
+            memory: 4Gi
+    volumes:
+      - name: pod-templates
+        configMap:
+          name: efi-cirrus-hook-template

--- a/github-actions/cirrus-espm-hook-template.yaml
+++ b/github-actions/cirrus-espm-hook-template.yaml
@@ -31,6 +31,20 @@ data:
       automountServiceAccountToken: false
       containers:
         - name: $job
+          env:
+            # rocker/ml bakes HOME=/home/jovyan into the image, but we run the
+            # job as uid 1001 (see securityContext below), which cannot read
+            # jovyan's home — git then dies with
+            #   EACCES: permission denied, stat '/home/jovyan/.gitconfig'
+            # Pod env overrides image env, so point HOME somewhere the job user
+            # can actually write. Needed for any image whose default user is not
+            # 1001, which is most of them.
+            #
+            # /tmp specifically: it always exists and is world-writable (1777).
+            # A path under /__w would also be writable but would have to be
+            # created first, and nothing creates HOME for you.
+            - name: HOME
+              value: /tmp
           resources:
             requests:
               memory: 1Gi
@@ -40,6 +54,15 @@ data:
               # three sets, so the worst case stays well inside cirrus's RAM.
               memory: 8Gi
           securityContext:
-            runAsUser: 0
+            # 1001, NOT 0. The workspace (_work, mounted at /__w) is created by
+            # the runner container, which runs as `runner` = uid 1001, so the job
+            # container must be 1001 to write to it. rocker/ml defaults to
+            # `jovyan` (uid 1000) and therefore fails every job at the first
+            # action with:
+            #   EACCES: permission denied, open '/__w/_temp/_runner_file_commands/...'
+            # Root (runAsUser: 0) also fixes that, but by bypassing permissions
+            # rather than matching them — unnecessary here, since nothing in the
+            # coursework needs root and rocker images ship passwordless sudo.
+            runAsUser: 1001
             allowPrivilegeEscalation: false
             privileged: false

--- a/github-actions/cirrus-espm-hook-template.yaml
+++ b/github-actions/cirrus-espm-hook-template.yaml
@@ -1,0 +1,45 @@
+# Hook pod template shared by the espm-157 and espm-288 runner scale sets
+# (containerMode: kubernetes). See cirrus-efi-hook-template.yaml for the full
+# explanation of how these extensions work; the short version is that `$job`
+# (CONTAINER_EXTENSION_PREFIX "$" + JOB_CONTAINER_NAME "job") targets the
+# workflow's job container, and resources/securityContext are overwritten while
+# name/image are protected.
+#
+# One ConfigMap serves both sets: they are in the same namespace and want the
+# same policy. Student coursework is far lighter than the eco4cast forecast
+# jobs, hence the smaller ceiling than efi-cirrus's 45Gi.
+#
+# Deliberately no `capabilities: drop: [ALL]` — that revokes CAP_DAC_OVERRIDE,
+# and a uid-0 job container then cannot write to _work/_temp (owned by the
+# runner's uid 1001). It fails every job at the first action with EACCES.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: espm-hook-template
+  namespace: arc-runners
+data:
+  default.yaml: |
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      name: espm-job-pod
+    spec:
+      # The kube-mode ServiceAccount holds secrets get/list in arc-runners,
+      # which is where the GitHub PAT lives. Workflow steps run in THIS pod, so
+      # refuse the token projection — this matters more here than for eco4cast,
+      # because these runners execute student-authored code.
+      automountServiceAccountToken: false
+      containers:
+        - name: $job
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 250m
+            limits:
+              # Caps a runaway student job. Two concurrent runners per set,
+              # three sets, so the worst case stays well inside cirrus's RAM.
+              memory: 8Gi
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: false
+            privileged: false

--- a/github-actions/cirrus-espm157-values.yaml
+++ b/github-actions/cirrus-espm157-values.yaml
@@ -1,73 +1,58 @@
 githubConfigUrl: "https://github.com/espm-157"
+# Consolidated onto the single github-runner-token secret. Live state had
+# drifted to a chart-generated arc-runner-espm157-gha-rs-github-secret while
+# this file still said github-runner-token, so a helm upgrade from here would
+# have silently repointed it. All sets now share one secret: one thing to
+# rotate, and no chance of a stale copy going unnoticed the next time the PAT
+# expires (which is what caused the 2026-07-19 outage).
 githubConfigSecret: github-runner-token
 maxRunners: 2
 runnerGroup: "default"
 
-## Container mode is an object that provides out-of-box configuration
-## for dind and kubernetes mode. Template will be modified as documented under the
-## template object.
-##
-## If any customization is required for dind or kubernetes mode, containerMode should remain
-## empty, and configuration should be applied to the template.
-#containerMode:
-#  type: "dind"  ## type can be set to dind or kubernetes
-## template is the PodSpec for each runner Pod
-## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+# containerMode: kubernetes — replaces the previous privileged docker:dind
+# template. Under dind, any student workflow landing on this runner could drive
+# a privileged Docker socket and become root on cirrus, which is the cluster's
+# only node and its control plane. That is a particularly bad property for a
+# runner that executes coursework from student-owned repositories.
+#
+# TRADE-OFF, read before reusing: kubernetes mode sets
+# ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER=true, so every job on this runner MUST
+# declare `container:`. Existing student repos that just do
+# `runs-on: arc-runner-espm157` with no container will fail here. That is
+# accepted: the course templates are being updated so new repos comply, and
+# older repos are not active. `options:` is also unsupported — see
+# cirrus-espm-hook-template.yaml, which is where resource/user settings live.
+containerMode:
+  type: "kubernetes"
+  kubernetesModeWorkVolumeClaim:
+    # MUST be RWX — runner pod and job pod both mount _work.
+    accessModes: ["ReadWriteMany"]
+    storageClassName: "juicefs-sc"
+    resources:
+      requests:
+        storage: 20Gi
+
 template:
-  ## template.spec will be modified if you change the container mode
-  ## with containerMode.type=dind, we will populate the template.spec with following pod spec
-     spec:
-       initContainers:
-       - name: init-dind-externals
-         image: ghcr.io/actions/actions-runner:latest
-         command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
-         volumeMounts:
-           - name: dind-externals
-             mountPath: /home/runner/tmpDir
-       containers:
-       - name: runner
-         image: ghcr.io/actions/actions-runner:latest
-         command: ["/home/runner/run.sh"]
-         resources: 
-           requests:
-             memory: "1Gi"
-           limits:
-             memory: "5Gi"
-         env:
-           - name: DOCKER_HOST
-             value: unix:///var/run/docker.sock
-         volumeMounts:
-           - name: work
-             mountPath: /home/runner/_work
-           - name: dind-sock
-             mountPath: /var/run
-       - name: dind
-         image: docker:dind
-         resources: 
-           requests:
-             memory: "1Gi"
-           limits:
-             memory: "5Gi"
-         args:
-           - dockerd
-           - --host=unix:///var/run/docker.sock
-           - --group=$(DOCKER_GROUP_GID)
-         env:
-           - name: DOCKER_GROUP_GID
-             value: "123"
-         securityContext:
-           privileged: true
-         volumeMounts:
-           - name: work
-             mountPath: /home/runner/_work
-           - name: dind-sock
-             mountPath: /var/run
-           - name: dind-externals
-             mountPath: /home/runner/externals
-       volumes:
-       - name: work
-         emptyDir: {}
-       - name: dind-sock
-         emptyDir: {}
-       - name: dind-externals
-         emptyDir: {}
+  spec:
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+            value: /home/runner/pod-templates/default.yaml
+        volumeMounts:
+          - name: pod-templates
+            mountPath: /home/runner/pod-templates
+            readOnly: true
+        resources:
+          requests:
+            memory: 512Mi
+          limits:
+            # Orchestration only; the student code runs in the job pod, capped
+            # separately in the hook template.
+            memory: 2Gi
+    volumes:
+      - name: pod-templates
+        configMap:
+          name: espm-hook-template

--- a/github-actions/cirrus-espm288-values.yaml
+++ b/github-actions/cirrus-espm288-values.yaml
@@ -1,73 +1,48 @@
 githubConfigUrl: "https://github.com/espm-288"
+# Consolidated onto the single github-runner-token secret — see the note in
+# cirrus-espm157-values.yaml.
 githubConfigSecret: github-runner-token
 maxRunners: 2
 runnerGroup: "default"
 
-## Container mode is an object that provides out-of-box configuration
-## for dind and kubernetes mode. Template will be modified as documented under the
-## template object.
-##
-## If any customization is required for dind or kubernetes mode, containerMode should remain
-## empty, and configuration should be applied to the template.
-#containerMode:
-#  type: "dind"  ## type can be set to dind or kubernetes
-## template is the PodSpec for each runner Pod
-## For reference: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+# containerMode: kubernetes — replaces the previous privileged docker:dind
+# template, which gave any student workflow a path to root on cirrus (the
+# cluster's only node and its control plane).
+#
+# TRADE-OFF: kubernetes mode sets ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER=true, so
+# every job here MUST declare `container:`, and `options:` is unsupported.
+# Lowest-risk of the three sets to convert: no espm-288 template repo references
+# this runner, and it ran zero self-hosted jobs in the three months to
+# 2026-08-12. See cirrus-espm-hook-template.yaml for resource/user settings.
+containerMode:
+  type: "kubernetes"
+  kubernetesModeWorkVolumeClaim:
+    # MUST be RWX — runner pod and job pod both mount _work.
+    accessModes: ["ReadWriteMany"]
+    storageClassName: "juicefs-sc"
+    resources:
+      requests:
+        storage: 20Gi
+
 template:
-  ## template.spec will be modified if you change the container mode
-  ## with containerMode.type=dind, we will populate the template.spec with following pod spec
-     spec:
-       initContainers:
-       - name: init-dind-externals
-         image: ghcr.io/actions/actions-runner:latest
-         command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
-         volumeMounts:
-           - name: dind-externals
-             mountPath: /home/runner/tmpDir
-       containers:
-       - name: runner
-         image: ghcr.io/actions/actions-runner:latest
-         command: ["/home/runner/run.sh"]
-         resources: 
-           requests:
-             memory: "1Gi"
-           limits:
-             memory: "5Gi"
-         env:
-           - name: DOCKER_HOST
-             value: unix:///var/run/docker.sock
-         volumeMounts:
-           - name: work
-             mountPath: /home/runner/_work
-           - name: dind-sock
-             mountPath: /var/run
-       - name: dind
-         image: docker:dind
-         resources: 
-           requests:
-             memory: "1Gi"
-           limits:
-             memory: "5Gi"
-         args:
-           - dockerd
-           - --host=unix:///var/run/docker.sock
-           - --group=$(DOCKER_GROUP_GID)
-         env:
-           - name: DOCKER_GROUP_GID
-             value: "123"
-         securityContext:
-           privileged: true
-         volumeMounts:
-           - name: work
-             mountPath: /home/runner/_work
-           - name: dind-sock
-             mountPath: /var/run
-           - name: dind-externals
-             mountPath: /home/runner/externals
-       volumes:
-       - name: work
-         emptyDir: {}
-       - name: dind-sock
-         emptyDir: {}
-       - name: dind-externals
-         emptyDir: {}
+  spec:
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+            value: /home/runner/pod-templates/default.yaml
+        volumeMounts:
+          - name: pod-templates
+            mountPath: /home/runner/pod-templates
+            readOnly: true
+        resources:
+          requests:
+            memory: 512Mi
+          limits:
+            memory: 2Gi
+    volumes:
+      - name: pod-templates
+        configMap:
+          name: espm-hook-template

--- a/monitoring/prometheus-values.yaml
+++ b/monitoring/prometheus-values.yaml
@@ -9,11 +9,81 @@ kube-state-metrics:
 # so :9100 is free again and ours uses the default.)
 prometheus-node-exporter:
   enabled: true
+  # CARDINALITY GUARD. Without these the filesystem collector reports every
+  # kubelet pod-volume bind mount and every containerd sandbox /shm — 325k
+  # distinct `mountpoint` values on cirrus alone (230k under
+  # /var/lib/kubelet/pods, 95k under /run/k3s/containerd), each × ~8
+  # node_filesystem_* metrics, and every one of them churns to a brand-new
+  # series when a pod restarts. Millions of head series on its own.
+  extraArgs:
+    - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|run/containerd/.+|var/lib/docker/.+|var/lib/kubelet/.+|var/lib/rancher/.+)($|/)
+    - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
 prometheus-pushgateway:
   enabled: false
 
 server:
   retention: "15d"
+  # Second brake: never let the TSDB fill the volume. A full /data stops
+  # compaction, which pins everything in the head — that is how RAM ran away.
+  retentionSize: "40GB"
   persistentVolume:
     storageClass: openebs-zfs
-    size: 5Gi
+    size: 100Gi
+  resources:
+    requests:
+      cpu: 200m
+      memory: 1Gi
+    limits:
+      memory: 8Gi
+
+# ---------------------------------------------------------------------------
+# Scrape jobs. The chart exposes its defaults as a map keyed by job name, so
+# these entries patch/disable individual jobs rather than restating the list.
+#
+# The stock kubernetes-nodes / kubernetes-nodes-cadvisor jobs do
+# `labelmap __meta_kubernetes_node_label_(.+)`, which stamps all 127 node
+# labels — including 88 NFD feature.node.kubernetes.io/* labels — onto every
+# series from those jobs. Prometheus reported 0.5–1.3 GB of label memory *per
+# NFD label*. Both jobs below set an explicit `node` label instead.
+# ---------------------------------------------------------------------------
+scrapeConfigs:
+  # Nothing in this cluster sets the prometheus.io/scrape_slow annotation, and
+  # there is no blackbox-exporter behind kubernetes-services. All had 0 targets.
+  kubernetes-pods-slow:
+    enabled: false
+  kubernetes-service-endpoints-slow:
+    enabled: false
+  kubernetes-services:
+    enabled: false
+  prometheus-pushgateway:
+    enabled: false
+
+  kubernetes-nodes:
+    relabel_configs:
+      - action: replace
+        source_labels: [__meta_kubernetes_node_name]
+        target_label: node
+
+  # cAdvisor raw output is ~2M series here (container_tasks_state,
+  # container_memory_failures_total, and a per-cgroup `id`/`name` label pair for
+  # every systemd slice on the box). No dashboard in this repo reads container_*,
+  # so keep a small allowlist for ad-hoc per-pod queries and drop the rest.
+  kubernetes-nodes-cadvisor:
+    relabel_configs:
+      - action: replace
+        source_labels: [__meta_kubernetes_node_name]
+        target_label: node
+    metric_relabel_configs:
+      - action: keep
+        regex: container_(cpu_usage_seconds_total|memory_working_set_bytes|memory_rss|network_(receive|transmit)_bytes_total|fs_(reads|writes)_bytes_total)
+        source_labels: [__name__]
+      # Node-level cgroups (systemd slices, kubepods roots) carry no container
+      # label and are not worth a series each.
+      - action: drop
+        regex: ""
+        source_labels: [container]
+      # `id` (cgroup path) and `name` (runtime container name) are the two
+      # highest-cardinality labels cAdvisor emits — ~193k and ~74k distinct
+      # values — and both are redundant with namespace/pod/container.
+      - action: labeldrop
+        regex: (id|name)


### PR DESCRIPTION
Two independent pieces of work on cirrus. **Both are already applied to the live
cluster** — this PR brings the repo back in sync with what is running.

## Prometheus: 76 GiB RSS -> ~0.6 GiB

`prometheus-server` held **12,664,279** active head series with no memory limit,
on a 5Gi PVC that was 100% full — so compaction had stalled, which is why the
head never shrank. Three causes:

- **node-exporter had no filesystem mount exclusions**, so it exported
  `node_filesystem_*` for all 325k mountpoints on the host: 230k kubelet
  pod-volume bind mounts and 95k containerd sandbox `/shm` mounts, each churning
  to a fresh series on every pod restart.
- **The node/cadvisor jobs did a blanket `labelmap` of all node labels**,
  stamping 127 labels — 88 of them NFD `feature.node.kubernetes.io/*` — onto
  every series from those jobs. Prometheus reported 0.5–1.3 GB of label memory
  *per NFD label*.
- **Raw cAdvisor** added ~2M series. No dashboard here reads `container_*`, so
  it now keeps a small allowlist and drops per-cgroup `id`/`name`.

Also PVC 5Gi -> 100Gi with `retention.size=40GB` so a full volume can never
stall compaction again, an 8Gi memory limit, and the four zero-target jobs
disabled.

Result: **12,664,279 -> 138,376 series**, 701,389 -> 5,044 label pairs,
262,275 -> 195 mountpoints, **76,515Mi -> ~600Mi RSS**. All dashboard metrics
verified still present. The TSDB was wiped, so history restarts 2026-08-11.

## ARC runners: no privileged containers anywhere

All three scale sets ran `docker:dind` with `privileged: true`, sharing
`/var/run` with the runner via `DOCKER_HOST`. Any workflow job could therefore
drive a privileged Docker socket and become root on cirrus — which since thelio
was decommissioned is the only node *and* the control plane, so the reachable
blast radius was every secret in the cluster plus the CA keys. On the espm
runners that code is student-authored.

All three now use `containerMode: kubernetes` (job containers as sibling pods,
no Docker daemon), and `arc-runners` is labelled PodSecurity
`enforce=baseline` — verified enforcing: a privileged probe pod is rejected by
the API server. That is the layer that matters, since kube-mode grants the
runner ServiceAccount pod-create.

Job pods also set `automountServiceAccountToken: false`; the chart's kube-mode
SA necessarily holds `secrets: get,list` in the namespace that stores the PAT.

Two non-obvious things, both found by testing:

- **Do not set `capabilities: drop: [ALL]`.** It revokes CAP_DAC_OVERRIDE, so a
  uid-0 job container cannot write to `_work/_temp` (owned by the runner's uid
  1001) and every job dies at the first action with `EACCES`.
- **espm job containers run as uid 1001, not root.** `rocker/ml` defaults to
  `jovyan` (1000) while the workspace is owned by `runner` (1001). Root also
  "fixes" this, but by bypassing permission checks rather than matching them.
  Matching the uid additionally required `HOME=/tmp`, since the image bakes
  `HOME=/home/jovyan`, which 1001 cannot read.

Consolidation: `arc-runner-eco4cast` was redundant with `efi-cirrus` (same org,
same runner group, same host) and is uninstalled; `efi-cirrus` goes to
`maxRunners: 2` so the two jobs that both fire at 23:00 UTC still run
concurrently instead of serialising. `arc-runner-espm157-f24`, a Fall-2024
one-off, is also gone. All three remaining sets now share one
`github-runner-token` secret — the values files had drifted to names that did
not match live, so any `helm upgrade` from this repo would have silently
repointed them.

### Known breaking change

kubernetes mode sets `ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER=true`, so **every job
on these runners must declare `container:`**, and `options:` is unsupported
(resource limits live in the hook templates instead). Course templates and the
eco4cast workflows were updated accordingly; older student repos without a
`container:` will fail on these runners.

### Verified on the live cluster

- eco4cast `usgsrc4cast-ci/drivers_stage3` green end to end
- espm-157 coursework green on a private repo: checkout, setup-python,
  pip install, pytest — as uid 1001, non-privileged
- 8Gi ceiling confirmed enforced: `memory.max = 8589934592` read from inside a
  live job container, and a probe pod OOMKilled (exit 137) at ~8 GiB