### PR TITLE
images: add armadactl and the Secret Service stack it needs

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -20,6 +20,12 @@ RUN install -d -o "${NB_USER}" -g "${NB_USER}" -m 0700 "${HOME}/.kube" && \
     rm /tmp/kubeconfig && \
     rm -f "${HOME}/install_llms.sh" "${HOME}/install.r"
 
+# armadactl, for the Armada batch queue on NRP. Also installs the D-Bus +
+# Secret Service stack it needs to cache its OIDC token; without that it
+# re-authenticates on every invocation, and NRP's device codes expire in 60s.
+COPY install-armada.sh /tmp/install-armada.sh
+RUN bash /tmp/install-armada.sh && rm /tmp/install-armada.sh
+
 COPY install-claude.sh /tmp/install-claude.sh
 RUN bash /tmp/install-claude.sh && rm /tmp/install-claude.sh
 

--- a/images/install-armada.sh
+++ b/images/install-armada.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# install-armada.sh
+#
+# Installs armadactl, the CLI for the Armada batch job queue used on NRP
+# Nautilus, together with the D-Bus + Secret Service stack armadactl needs in
+# order to cache its OIDC token.
+#
+# Armada matters because it is not bound by the Kubernetes indexed-Job
+# completion cap (~200, an etcd pressure limit), so work can be split into
+# thousands of small jobs instead of hundreds of large ones. Small jobs lose
+# minutes rather than hours to preemption, request what one step needs instead
+# of the peak of a long chain, and pack into free scraps instead of waiting for
+# large contiguous slots.
+#
+# No credentials are written by this script. A config file pointing at the NRP
+# Armada server is installed, but authentication happens after startup.
+
+set -euo pipefail
+
+curl_retry() { curl --retry 5 --retry-delay 3 --retry-all-errors -fsSL "$@"; }
+
+# --------------------------------------------------------------------------
+# Architecture detection
+# --------------------------------------------------------------------------
+case "$(uname -m)" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+    *)
+        echo "ERROR: Unsupported architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+echo "==> Detected architecture: ${ARCH}"
+
+# --------------------------------------------------------------------------
+# Secret Service, for armadactl's OIDC token cache
+#
+# armadactl caches its refresh token through go-keyring, which on Linux talks
+# to a D-Bus Secret Service. Without one it fails with
+#
+#   failed to save refresh token to keyring: exec: "dbus-launch": executable
+#   file not found in $PATH
+#
+# and then re-authenticates on EVERY invocation — which, given NRP's device
+# codes expire in 60 seconds, makes the CLI painful to use and impossible to
+# automate. These three packages supply the session bus, the secret store, and
+# the secret-tool CLI used to verify it.
+# --------------------------------------------------------------------------
+echo "==> Installing D-Bus + Secret Service (armadactl token cache)..."
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq --no-install-recommends \
+    dbus-x11 \
+    gnome-keyring \
+    libsecret-tools
+rm -rf /var/lib/apt/lists/*
+
+# --------------------------------------------------------------------------
+# Install armadactl
+#
+# Resolve the latest tag via the github.com redirect rather than the
+# api.github.com REST endpoint, which is rate-limited for anonymous CI builds.
+# --------------------------------------------------------------------------
+echo "==> Installing armadactl..."
+
+ARMADA_VERSION="$(
+    curl_retry -o /dev/null -w '%{url_effective}' \
+        https://github.com/armadaproject/armada/releases/latest \
+    | sed 's#.*/tag/v##'
+)"
+echo "    Latest version: ${ARMADA_VERSION}"
+
+curl_retry \
+    "https://github.com/armadaproject/armada/releases/download/v${ARMADA_VERSION}/armadactl_${ARMADA_VERSION}_linux_${ARCH}.tar.gz" \
+    -o /tmp/armadactl.tar.gz
+
+mkdir -p /tmp/armadactl-extract
+tar xzf /tmp/armadactl.tar.gz -C /tmp/armadactl-extract
+
+install -o root -g root -m 0755 \
+    /tmp/armadactl-extract/armadactl \
+    /usr/local/bin/armadactl
+
+rm -rf /tmp/armadactl.tar.gz /tmp/armadactl-extract
+
+echo "    armadactl ${ARMADA_VERSION} installed to /usr/local/bin/armadactl"
+
+# --------------------------------------------------------------------------
+# Ship a default NRP config
+#
+# This uses openIdDeviceAuth, NOT the openIdAuth (PKCE) flow that NRP's own
+# published config uses. PKCE binds 127.0.0.1:50000 and waits for a browser
+# redirect, so it CANNOT complete in a headless container: it hangs silently,
+# prints no URL, and keeps holding the port, so every later attempt dies with
+# "bind: address already in use". The device flow prints a URL to approve on
+# any device and needs no local callback port.
+#
+# Contains no secrets — the client id and endpoints are public. Follows the
+# same pattern as the shipped kubeconfig: on JupyterHub this file is shadowed
+# by the PVC mounted over the home directory, so it only takes effect for
+# independent (non-hub) use of the image.
+# --------------------------------------------------------------------------
+echo "==> Installing default armadactl config..."
+
+cat > /tmp/armadactl.yaml <<'YAML'
+currentContext: main
+contexts:
+  main:
+    cacheRefreshToken: true
+    armadaUrl: armada.nrp-nautilus.io:50051
+    openIdDeviceAuth:
+      providerUrl: "https://authentik.nrp-nautilus.io/application/o/armada/"
+      clientId: "8AeUAhsM1rA8WRJoX586BhJk8t5Icfrm169ESz8Y"
+      scopes:
+        - "openid"
+        - "profile_prefixed"
+        - "offline_access"
+YAML
+
+install -o "${NB_USER}" -g "${NB_USER}" -m 0600 \
+    /tmp/armadactl.yaml "${HOME}/.armadactl.yaml"
+rm /tmp/armadactl.yaml
+
+echo "    config installed to ${HOME}/.armadactl.yaml"
+
+# --------------------------------------------------------------------------
+# Verify installs
+# --------------------------------------------------------------------------
+echo ""
+echo "==> Verifying installs..."
+armadactl version 2>/dev/null | head -2 || true
+for b in dbus-run-session gnome-keyring-daemon secret-tool; do
+    printf '    %-24s %s\n' "$b" "$(command -v "$b" || echo MISSING)"
+done
+
+# --------------------------------------------------------------------------
+# Post-install instructions
+# --------------------------------------------------------------------------
+echo ""
+echo "=========================================================="
+echo "  armadactl installed successfully."
+echo "=========================================================="
+echo ""
+echo "Queues correspond to cluster namespaces; submit to the ones you"
+echo "normally access. You do not create a queue."
+echo ""
+echo "  armadactl get queues"
+echo "  armadactl submit jobs.yaml"
+echo ""
+echo "Monitor at https://armada-lookout.nrp-nautilus.io"
+echo ""
+echo "AUTHENTICATION"
+echo ""
+echo "  The device code expires in 60 SECONDS. Have the browser ready before"
+echo "  you run the command, then approve the printed URL immediately."
+echo ""
+echo "  To have the token cached so you authenticate once rather than on every"
+echo "  command, run under a session bus with an unlocked keyring:"
+echo ""
+echo "      dbus-run-session -- bash -c '\\"
+echo "        echo -n \"\" | gnome-keyring-daemon --unlock --components=secrets; \\"
+echo "        armadactl get queues'"
+echo ""
+echo "  Without a session bus armadactl warns \"Failed to save token to cache\""
+echo "  and re-authenticates every time. That is survivable for a submit — one"
+echo "  call can carry thousands of jobs — but not for unattended use."
+echo ""
+echo "  For cron or an always-on agent, prefer a non-interactive method:"
+echo "  execAuth (a command that returns a token) or"
+echo "  openIdClientCredentialsAuth (a service-account client)."
+echo "=========================================================="


### PR DESCRIPTION
Adds `armadactl` to the default CPU image, plus the D-Bus + Secret Service packages it needs to cache its token.

Everything here was verified in a running container of the current image before writing the installer.

## Why the keyring packages are not optional

`armadactl` caches its OIDC refresh token through `go-keyring`, which on Linux talks to a D-Bus Secret Service. The image has none, so it fails with:

```
Failed to save token to cache
error="failed to save refresh token to keyring: exec: \"dbus-launch\": executable file not found in $PATH"
```

and **re-authenticates on every invocation**. NRP's device codes expire in **60 seconds** (measured against authentik: `expires_in: 60`, `interval: 5` — not the usual 5–10 minutes), so this makes the CLI a scramble interactively and impossible to automate.

Verified the fix works headlessly in the current image:

```
$ dbus-run-session -- bash -c 'echo -n "" | gnome-keyring-daemon --unlock --components=secrets
                               echo -n hello-armada | secret-tool store --label=t svc a key t
                               secret-tool lookup svc a key t'
hello-armada
```

## Why the shipped config uses the device flow, not NRP's published one

The config NRP publishes at `https://nrp.ai/.armadactl.yaml` uses PKCE (`openIdAuth`), which binds `127.0.0.1:50000` and waits for a browser redirect. **That cannot complete in a container**: it hangs silently, prints no URL, and keeps holding the port, so every later attempt dies with `panic: bind: address already in use` — which reads as a different fault and sends you chasing the wrong thing.

`openIdDeviceAuth` prints a URL to approve on any device with no local callback port. Authentik supports it (`device_authorization_endpoint` and `urn:ietf:params:oauth:grant-type:device_code` are both in its OIDC discovery); it is simply undocumented on the NRP page.

The config carries **no secrets** — client id and endpoints are public — and follows the existing shipped-kubeconfig pattern, so on JupyterHub it is shadowed by the PVC over the home directory and only applies to standalone `docker run` use.

## Why armadactl is worth having in the image

Armada is not bound by the Kubernetes indexed-Job completion cap (~200, an etcd pressure limit), so work can be split into thousands of small jobs rather than hundreds of large ones. On a real workload (CHELSA bioclimate hexing, boettiger-lab/data-workflows#564) the k8s shape was 122 pods x 3.5 h x 64Gi; the same work microslices to 4,270 jobs of ~5 min at 32Gi. That changes four things at once: the unit of loss on preemption drops from hours to minutes, each job requests what one step needs instead of the peak of a 35-step chain, small pods pack into free scraps instead of waiting for large contiguous slots, and a straggler retries invisibly instead of holding up a batch.

Measured: a 5-job set went from `armadactl submit` to all five pods **Running in ~13 seconds**.

## Verified before writing

- version resolution via the github.com redirect (avoiding the rate-limited REST API, matching `install-kubectl-tools.sh`) resolves `v0.22.7`, and the download URL returns HTTP 200
- `armadactl` runs, connects to `armada.nrp-nautilus.io:50051`, and lists 1,875 queues (one per namespace)
- the Secret Service round-trip above
- `bash -n` on the installer

## Notes for review

- **Port 50051**, not 443. A plain HTTPS GET to the host returns 502, which looks like a broken endpoint if you guess 443.
- Scoped to `images/Dockerfile` only. `Dockerfile.gpu` is a separate `FROM rocker-org/cuda` and does not install kubectl either, so I left it alone — happy to add it if you would rather the images match.
- The installer's post-install text documents the 60-second expiry, the `dbus-run-session` incantation for token caching, and `execAuth` / `openIdClientCredentialsAuth` as the right answers for unattended use.
