### PR TITLE
k3s: document the drain-before-reboot procedure for JuiceFS nodes

### DIFF
--- a/k3s/README.md
+++ b/k3s/README.md
@@ -116,3 +116,14 @@ cp /etc/rancher/k3s/k3s.yaml ~/k3s-remote-kubeconfig.yaml
 # Edit and replace 127.0.0.1 with your server's IP or hostname
 sed -i 's/127.0.0.1/YOUR_SERVER_IP/g' ~/k3s-remote-kubeconfig.yaml
 ```
+
+## Node Maintenance
+
+Rebooting a worker node that has JuiceFS volumes mounted will hang at
+shutdown unless you drain it first. See
+[`node-drain-reboot.md`](node-drain-reboot.md) for the ordered drain,
+verify, stop-agent, reboot procedure — and for cleaning up the stranded
+CSI deletion jobs left behind by a hard power cycle.
+
+Note that `cirrus` must never be cordoned or drained: it is the control
+plane, the storage node, and the compute node at once.

--- a/k3s/node-drain-reboot.md
+++ b/k3s/node-drain-reboot.md
@@ -1,0 +1,137 @@
+# Draining and rebooting a worker node
+
+Rebooting a k3s worker that has JuiceFS (FUSE) volumes mounted will **hang
+indefinitely at shutdown** if you just run `sudo reboot`. The symptom is a
+console stuck on a `Waiting for ...juicefs...` job that never times out,
+which leaves a hard power cycle as the only way out — and a hard power cycle
+on a node with an active FUSE mount can leave stale mountpoints and stranded
+CSI cleanup jobs behind.
+
+This is the ordered procedure that avoids that.
+
+## Why it hangs
+
+The JuiceFS CSI driver runs in **mount-pod mode** (`juicefs-csi-node`
+DaemonSet in `kube-system`, no `--by-process` flag). Each volume is served by
+a separate mount pod, also in `kube-system`, which holds the FUSE connection
+backing `/var/lib/juicefs/volume/...` and the kubelet bind-mounts under
+`/var/lib/kubelet/pods/*/volumes/kubernetes.io~csi/*/mount`.
+
+At shutdown, systemd stops containerd (killing the mount pods) and then tries
+to unmount the filesystems. Once the FUSE server process is gone, nothing is
+left to answer the kernel, so `umount` blocks in uninterruptible sleep and
+systemd waits on it forever.
+
+The fix is to make Kubernetes tear the mounts down **in order**, while the
+mount pods are still alive, before touching the OS.
+
+## Procedure
+
+Run these from a machine with cluster admin (cirrus, or your laptop with the
+remote kubeconfig). Substitute the node name for `<node>`.
+
+### 1. Cordon and drain
+
+```bash
+kubectl cordon <node>
+
+kubectl drain <node> \
+  --ignore-daemonsets \
+  --delete-emptydir-data \
+  --timeout=10m
+```
+
+`--ignore-daemonsets` is required: DaemonSet pods (`juicefs-csi-node`,
+device plugin, node exporters, `svclb-*`) are not evicted by drain and will
+be handled in the next step.
+
+> **Never cordon or drain `cirrus`.** It is simultaneously the control plane,
+> the storage node, and the compute node — cordoning it strands every
+> workload in the cluster. This is why both system-upgrade plans in
+> `upgrade/plans.yml` pin `cordon: false`. This procedure is for *worker*
+> nodes only.
+
+### 2. Confirm the JuiceFS mounts are actually gone
+
+Drain evicts the workload pods, which releases the volumes, which lets the
+CSI driver reap the mount pods. That last step is asynchronous — wait for it
+rather than assuming it.
+
+```bash
+# No mount pods left for this node (should return nothing):
+kubectl get pods -n kube-system -o wide | grep juicefs | grep <node>
+
+# And on the node itself, no FUSE mounts left (should return nothing):
+ssh <node> 'mount | grep -i juicefs'
+```
+
+Do not proceed until both are empty. If mount pods linger, find what is still
+holding the volume:
+
+```bash
+kubectl get pods -A -o wide --field-selector spec.nodeName=<node>
+```
+
+### 3. Stop the k3s agent
+
+```bash
+ssh <node> 'sudo systemctl stop k3s-agent'
+```
+
+Stopping the agent cleanly — rather than letting the shutdown sequence race
+it — ensures containerd shuts down with no volumes still attached.
+
+### 4. Reboot
+
+```bash
+ssh <node> 'sudo systemctl reboot'
+```
+
+### 5. Uncordon after it returns
+
+```bash
+kubectl get nodes -w        # wait for <node> to report Ready
+kubectl uncordon <node>
+```
+
+## If it hangs anyway
+
+If the console is already stuck on a JuiceFS job, a hard power cycle is the
+only remaining option — but clean up afterwards, because the CSI volume
+deletion jobs that were mid-flight on that node become permanently stranded.
+
+Symptoms of the aftermath:
+
+```bash
+# Deletion jobs stuck Terminating on the dead node:
+kubectl get pods -n kube-system | grep delvol
+
+# Volumes stuck Released instead of being reclaimed:
+kubectl get pv | grep -v Bound
+```
+
+Those `Released` PVs still occupy space in the object store — the delete
+never ran. Clean-up options, in order of preference:
+
+1. **Bring the node back.** Once it is `Ready`, the stranded pods are
+   reconciled and the deletions finish on their own. Always try this first.
+2. **Delete the node object** if it is not coming back
+   (`kubectl delete node <node>`). This releases the stranded pods, and the
+   controller reschedules the outstanding deletion jobs onto a live node.
+3. Only if neither applies, force-delete the pods
+   (`kubectl delete pod -n kube-system <pod> --force`). This orphans the
+   underlying data in the object store, which then has to be reclaimed
+   manually.
+
+## Scope note
+
+Node-local storage does **not** follow the node. ZFS-LocalPV volumes
+(`openebs-zfs`) are pinned to the node that holds the pool, so a drained node
+cannot have its ZFS-backed workloads rescheduled elsewhere — they stay
+`Pending` until the node returns. Only RWX `juicefs-sc` volumes are portable
+between nodes. Check what a node is actually carrying before planning
+downtime:
+
+```bash
+kubectl get pvc -A -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,SC:.spec.storageClassName
+```


### PR DESCRIPTION
Rebooting a k3s worker that has JuiceFS volumes mounted hangs indefinitely at shutdown. The console sticks on a `Waiting for ...juicefs...` job that never times out, leaving a hard power cycle as the only way out — which in turn strands the in-flight CSI volume deletion jobs and leaves PVs `Released` with their backing data unreclaimed. This happened on `thelio` and is what produced the current batch of stuck `delvol` pods.

## Cause

The JuiceFS CSI driver runs in **mount-pod mode** — `juicefs-csi-node` is started with `--enable-manager=true` and no `--by-process` flag, and `JUICEFS_MOUNT_NAMESPACE` resolves to `kube-system` via the downward API. Each volume's FUSE connection is therefore served by a separate mount pod.

At shutdown, systemd stops containerd (killing those mount pods) and then tries to unmount the filesystems. With the FUSE server gone, nothing answers the kernel, so `umount` blocks in uninterruptible sleep and systemd waits on it forever.

## What this adds

`k3s/node-drain-reboot.md`, documenting the ordered procedure that makes Kubernetes tear the mounts down *while the mount pods are still alive*:

cordon → `drain --ignore-daemonsets` → **verify** no mount pods and no host FUSE mounts remain → `systemctl stop k3s-agent` → reboot → uncordon

The verify step is the one that matters: mount-pod reaping is asynchronous after eviction, so "drain returned" is not the same as "the mounts are gone."

Also covered:

- **Cleanup after a hard power cycle has already happened**, ranked: bring the node back, else `kubectl delete node`, and force-delete pods only as a last resort since it orphans data in the object store.
- **ZFS-LocalPV volumes are node-pinned** (`openebs-zfs`), so draining is not a general-purpose evacuation — those workloads stay `Pending` until the node returns. Only RWX `juicefs-sc` volumes are portable.
- **`cirrus` must never be cordoned or drained**, cross-referenced to `upgrade/plans.yml` where both upgrade plans pin `cordon: false` for the same reason.

Docs only — no manifest or config changes.