### PR TITLE
arc: pin runners to cirrus; juicefs: raise pg max_connections to 200

### DIFF
--- a/github-actions/cirrus-efi-hook-template.yaml
+++ b/github-actions/cirrus-efi-hook-template.yaml
@@ -34,6 +34,12 @@ data:
     metadata:
       name: efi-cirrus-job-pod
     spec:
+      # Pin job pods to cirrus as well. The runner pod's nodeSelector does NOT
+      # propagate: under containerMode kubernetes each `container:` job runs as
+      # a SIBLING pod created by the hooks, scheduled independently. Without
+      # this, a job pod can land on thelio even when its runner did not.
+      nodeSelector:
+        kubernetes.io/hostname: cirrus
       # The kube-mode ServiceAccount the chart generates holds
       # secrets: [get, list, create, delete] in arc-runners — the namespace that
       # also holds github-runner-token (the PAT). Workflow steps execute in THIS

--- a/github-actions/cirrus-efi-values.yaml
+++ b/github-actions/cirrus-efi-values.yaml
@@ -37,6 +37,14 @@ containerMode:
 
 template:
   spec:
+    # Pin every runner pod to cirrus. thelio rejoined the cluster on 2026-08-24
+    # but has unresolved disk health issues, and ARC's _work volumes are the
+    # heaviest storage churn in the cluster -- a runner landing there is exactly
+    # what must not happen. A cordon alone is not enough: it stops NEW pods but
+    # says nothing about intent, and it gets lifted. This makes the placement
+    # explicit and survives an uncordon.
+    nodeSelector:
+      kubernetes.io/hostname: cirrus
     containers:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest

--- a/github-actions/cirrus-espm-hook-template.yaml
+++ b/github-actions/cirrus-espm-hook-template.yaml
@@ -24,6 +24,12 @@ data:
     metadata:
       name: espm-job-pod
     spec:
+      # Pin job pods to cirrus as well. The runner pod's nodeSelector does NOT
+      # propagate: under containerMode kubernetes each `container:` job runs as
+      # a SIBLING pod created by the hooks, scheduled independently. Without
+      # this, a job pod can land on thelio even when its runner did not.
+      nodeSelector:
+        kubernetes.io/hostname: cirrus
       # The kube-mode ServiceAccount holds secrets get/list in arc-runners,
       # which is where the GitHub PAT lives. Workflow steps run in THIS pod, so
       # refuse the token projection — this matters more here than for eco4cast,

--- a/github-actions/cirrus-espm157-values.yaml
+++ b/github-actions/cirrus-espm157-values.yaml
@@ -34,6 +34,14 @@ containerMode:
 
 template:
   spec:
+    # Pin every runner pod to cirrus. thelio rejoined the cluster on 2026-08-24
+    # but has unresolved disk health issues, and ARC's _work volumes are the
+    # heaviest storage churn in the cluster -- a runner landing there is exactly
+    # what must not happen. A cordon alone is not enough: it stops NEW pods but
+    # says nothing about intent, and it gets lifted. This makes the placement
+    # explicit and survives an uncordon.
+    nodeSelector:
+      kubernetes.io/hostname: cirrus
     containers:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest

--- a/github-actions/cirrus-espm288-values.yaml
+++ b/github-actions/cirrus-espm288-values.yaml
@@ -26,6 +26,14 @@ containerMode:
 
 template:
   spec:
+    # Pin every runner pod to cirrus. thelio rejoined the cluster on 2026-08-24
+    # but has unresolved disk health issues, and ARC's _work volumes are the
+    # heaviest storage churn in the cluster -- a runner landing there is exactly
+    # what must not happen. A cordon alone is not enough: it stops NEW pods but
+    # says nothing about intent, and it gets lifted. This makes the placement
+    # explicit and survives an uncordon.
+    nodeSelector:
+      kubernetes.io/hostname: cirrus
     containers:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest

--- a/juicefs/postgres.yaml
+++ b/juicefs/postgres.yaml
@@ -6,7 +6,7 @@
 #
 # Secret `juicefs-pg` (key: password) must exist first — see credentials.example.yaml.
 #
-# NOTE: not yet applied. Apply with `kubectl apply -f juicefs/postgres.yaml`.
+# Apply with `kubectl apply -f juicefs/postgres.yaml`.
 ---
 apiVersion: v1
 kind: Namespace
@@ -50,6 +50,22 @@ spec:
       containers:
         - name: postgres
           image: postgres:16
+          # max_connections: 200, up from the postgres default of 100.
+          #
+          # On 2026-08-26 the JuiceFS CSI provisioner deadlocked against the
+          # default: 12 stuck delete-volume jobs each opened ~8 metadata
+          # connections on every respawn, saturated the 100 slots, and then
+          # could not complete -- so the controller recreated them, consuming
+          # more. Every client, including a plain `juicefs mount`, failed with
+          #   FATAL: sorry, too many clients already (SQLSTATE 53300)
+          # The loop could only be broken by scaling the controller to zero.
+          #
+          # 200 leaves headroom for a burst of concurrent mount/delvol jobs
+          # without letting a runaway loop take the filesystem index offline.
+          # The memory limit below is raised in step: Postgres reserves
+          # per-connection memory, so lifting the ceiling without it just moves
+          # the failure from connection exhaustion to an OOM kill.
+          args: ["-c", "max_connections=200"]
           ports:
             - containerPort: 5432
               name: postgres
@@ -74,7 +90,8 @@ spec:
               memory: "512Mi"
             limits:
               cpu: "1000m"
-              memory: "2Gi"
+              # 3Gi, raised alongside max_connections=200 above.
+              memory: "3Gi"
       volumes:
         - name: data
           persistentVolumeClaim:


### PR DESCRIPTION
Two fixes arising from the same incident: ARC `_work` volumes were piling up `Released` and never reclaiming their data — 11 stale PVs, and the count was still growing.

## Root cause

Not thelio, and not the CSI driver logic. The JuiceFS metadata Postgres runs at the stock `max_connections=100`, and a single JuiceFS client opens a sizeable metadata connection pool. Twelve stuck delete-volume jobs saturated the 100 slots on respawn, so no delvol job could complete, so the provisioner recreated them — consuming more. Self-sustaining.

Every client failed, including a plain `juicefs mount`:

```
FATAL: sorry, too many clients already (SQLSTATE 53300)
```

The loop could only be broken by scaling `juicefs-csi-controller` to zero. Confirmed by watching connections drop 100 → 6 the moment the jobs were deleted.

## Changes

**`juicefs/postgres.yaml`** — `max_connections` 100 → 200, memory limit 2Gi → 3Gi. The memory bump is not incidental: Postgres reserves per-connection memory, so raising the ceiling alone just trades connection exhaustion for an OOM kill. Also drops the stale `NOT yet applied` note — this has been deployed since 2026-06-28.

**ARC values (3 files) + hook templates (2 files)** — pin every ARC pod to `kubernetes.io/hostname: cirrus`. thelio rejoined on 2026-08-24 with unresolved disk health issues, and ARC `_work` volumes are the heaviest storage churn in the cluster.

Both halves are required. Under `containerMode: kubernetes` each workflow `container:` runs as a **sibling pod**, created by the runner-container-hooks and scheduled independently — the runner pod's `nodeSelector` does not propagate to it. Pinning only the runner would still let job pods land on thelio. A cordon is not a substitute: it does not survive an uncordon and does not record the intent.

## Verification

- All 11 `Released` PVs deleted; `juicefs-sc` PVs now 0, no finalizer hangs
- The 7 remaining ARC directories removed from the filesystem — it held **no non-ARC data**, so nothing else was at risk
- `max_connections=200` live and confirmed via `show max_connections`; CSI controller restored to 2 replicas with **zero** delvol jobs recreated and connections steady at 6
- Helm upgraded all three scale sets; `nodeSelector` confirmed on each `autoscalingrunnerset`, listeners healthy and back with the **same** hash (`754b578d`), so the stale scale-set-id trap did not trigger
- thelio cordoned; only DaemonSet pods remain there (`smartctl-exporter` and `dcgm-exporter` deliberately kept, since they are what report on the disks under investigation)

Actual data reclaimed was ~20 GB. The `100Gi` figures on those PVs are nominal requests — JuiceFS is elastic, so only real usage occupied rustfs.