### PR TITLE
juicefs: order shutdown cleanup against k3s.service too, not just the agent

### DIFF
--- a/juicefs/node-shutdown-cleanup.yaml
+++ b/juicefs/node-shutdown-cleanup.yaml
@@ -14,9 +14,11 @@
 # node-inotify.yaml, and likewise tolerates cordoned/tainted nodes.
 #
 # Ordering note: systemd stops units in the REVERSE of start order, so
-# "Before=k3s-agent.service" is what makes the cleanup run AFTER k3s-agent has
-# stopped. With After=, kubelet is still alive and simply recreates the mount
-# pods we just tore down (verified: 12 shims killed, 14 came back).
+# "Before=<k3s unit>" is what makes the cleanup run AFTER k3s has stopped. With
+# After=, kubelet is still alive and simply recreates the mount pods we just
+# tore down (verified: 12 shims killed, 14 came back). Both k3s-agent.service
+# and k3s.service are named, since agent nodes and the server use different
+# unit names and an unmatched ordering dependency is simply ignored.
 #
 # Deliberately NOT k3s-killall.sh: that also rm -rf's kubelet state, flushes
 # iptables and calls systemctl, none of which belong in a reboot path.
@@ -110,8 +112,16 @@ spec:
               Description=Unmount JuiceFS/kubelet mounts before systemd-shutdown
               Documentation=man:systemd.special(7)
               # systemd stops units in the REVERSE of start order, so Before= here means
-              # k3s-agent is stopped FIRST and this unit's ExecStop runs afterwards.
-              Before=k3s-agent.service
+              # k3s is stopped FIRST and this unit's ExecStop runs afterwards.
+              #
+              # BOTH unit names are listed on purpose: agent nodes (thelio) run
+              # k3s-agent.service, the server (cirrus) runs k3s.service. systemd
+              # silently ignores an ordering dependency naming a unit that does not
+              # exist, so each node picks up whichever applies and the other is a
+              # no-op. With only k3s-agent.service here, the ordering was inert on
+              # cirrus -- leaving the cleanup racing a still-live kubelet, which is
+              # the exact case this unit exists to avoid.
+              Before=k3s-agent.service k3s.service
               DefaultDependencies=no
               Before=umount.target shutdown.target
               Conflicts=umount.target


### PR DESCRIPTION
Follow-up to `juicefs/node-shutdown-cleanup.yaml`. The DaemonSet is applied and running on both nodes; this fixes an ordering gap that made it ineffective on cirrus.

## The problem

The installed unit ordered itself with:

```
Before=k3s-agent.service
```

cirrus is a k3s **server** and runs `k3s.service` — `k3s-agent.service` does not exist there:

```
$ systemctl list-units --type=service --all | grep k3s
  k3s.service   loaded active running   Lightweight Kubernetes
```

systemd silently ignores an ordering dependency naming a unit that isn't present, so on cirrus the directive was inert. The cleanup ended up ordered only against `umount.target`/`shutdown.target`, with **no ordering against k3s at all** — an unordered race in which the cleanup can fire while k3s and its embedded kubelet are still running.

That is exactly the failure the file's own comment documents and warns about:

> With `After=`, kubelet is still alive and simply recreates the mount pods we just tore down (verified: 12 shims killed, 14 came back).

It also matters more on cirrus than anywhere else: `/var/lib/kubelet` there holds all 21 ZFS-LocalPV jupyter home volumes.

thelio, an agent node, was correct as written.

## The fix

Name both units. An unmatched ordering dependency is a no-op, so each node picks up whichever applies and the other is ignored:

```
Before=k3s-agent.service k3s.service
```

## Verification

Applied to the live cluster; both nodes report `enabled / active`. systemd on cirrus resolved the ordering, and the reciprocal appears on the k3s side:

```
$ systemctl show k3s-shutdown-cleanup.service -p Before
Before=k3s.service umount.target shutdown.target k3s-agent.service

$ systemctl show k3s.service -p After | tr ' ' '\n' | grep shutdown-cleanup
k3s-shutdown-cleanup.service
```

So cirrus now stops k3s first and runs the FUSE teardown afterwards — the same guarantee thelio already had.

Comments updated to explain why both names are listed, so the next reader doesn't "simplify" it back to one.